### PR TITLE
Refactor 4A2A1-LDG_GEAR_PANEL.ino

### DIFF
--- a/embedded/OH4_Left_Console/4A2A1-LDG_GEAR_PANEL/4A2A1-LDG_GEAR_PANEL.ino
+++ b/embedded/OH4_Left_Console/4A2A1-LDG_GEAR_PANEL/4A2A1-LDG_GEAR_PANEL.ino
@@ -34,7 +34,7 @@
  * @file 4A2A1-LDG_GEAR_PANEL.ino
  * @author Arribe
  * @date 2/28/2024
- * @version 0.0.1
+ * @version 0.0.2
  * @brief Controls the LDG GEAR panel.
  *
  * @details
@@ -95,15 +95,15 @@
  * @brief Define Control I/O for DCS-BIOS. 
  * 
  */
-#define lgEmergSw A1
-#define lgOrideSw A2
-#define lgWarnSw A3
-#define lgLeverSol 2
-#define lgLimitSw 3
-#define lgLed 4
+const int lgEmergSw = A1;
+const int lgOrideSw = A2;
+const int lgWarnSw =  A3;
+const int lgLeverSol = 2;
+const int lgLimitSw = 3;
+const int lgLed = 4;
 
 /**
-* Declare variables for down lock logic
+* @brief Declare variables for down lock logic
 * initializing values for weight on wheels under a cold / onground start and down lock off.
 *
 */
@@ -172,10 +172,10 @@ void loop() {
   //Run DCS Bios loop function
   DcsBios::loop();
 
-  /*
+/**
 * If landing gear handle in down position and lock override pushed, then activate soleniod to unlock handle.
-* If landing gear handle in down position and NO weight on wheels the activate soleniod to unlock handle.
-* IF landing gear handle is down and there is weight on at least one wheel then turn off soleniod to lock handle down.
+* If landing gear handle in down position and NO weight on wheels, then activate soleniod to unlock handle.
+* IF landing gear handle is down and there is weight on at least one wheel, then turn off soleniod to lock handle down.
 * If landing gear handle is up turn off soleniod, handle cannot be locked in up position.
 * 
 * Note: digital reads of switch state will allow the landing gear handle to operate using the downlock override button


### PR DESCRIPTION
## Description

Updated landing gear sketch to fix landing gear handle logic to properly use Doxygen comment start '/**'.  Updated code to follow style guide.

Closes #42 

### Dependencies
* List any dependencies that are required for this change, including a full list of libraries required, especially if it is a new or otherwise unused library in the OpenHornet software.

### Type of change
- [ ] New software module (new software module for slave)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update outside of the automatically-generated Doxygen documentation.

### Checklist:
- [x] My code follows the [style guidelines](https://jrsteensen.github.io/OpenHornet-Software/d4/d46/md__2github_2workspace_2_s_t_y_l_e_g_u_i_d_e.html) of this project
- [x] [I have complied with the software manual](https://jrsteensen.github.io/OpenHornet-Software/d7/d78/md__software_manual.html) for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code fully with Doxygen compatible comments, particularly in hard-to-understand areas
- [x] I have made corresponding changes to non-Doxygen generated documentation
- [x] I have ran Doxygen locally, and it builds the docs successfully
- [x] My changes generate no errors on compile in Arduino IDE
- [x] My changes generate no new warnings on compile in Arduino IDE
- [x] Any dependent changes have been merged and published in downstream modules
- [x] (For sketches only) This sketch complies with OH-INTERCONNECT v**10**
- [ ] If this sketch requires additional libraries, [I have added it as a sub-module per the Arduino Libraries section of the Software Manual.](https://jrsteensen.github.io/OpenHornet-Software/d7/d78/md__software_manual.html)

### How Has This Been Tested?

- [ ] I have tested the sketch in-circuit in DCS with DCS-BIOS and outputs (displays, LEDs, etc.) function as expected. 
- [ ] I have tested the sketch in-circuit in DCS with DCS-BIOS and HID inputs (switches, pots, etc.) function as expected, with switches moving the correct direction.
- [x] I have tested the sketch in-circuit in DCS with DCS-BIOS and any logic in the sketch has been tested and functions as expected.
- [ ] This code has not yet been tested in-circuit.
- [ ] This code has not yet been tested in DCS-BIOS.

#### Description of Testing
<Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration>

#### Test Configuration
* Firmware version:
* Hardware:
* Toolchain:
* SDK: