### PR TITLE
refactor-4A2A1-LDG_GEAR_PANEL

### DIFF
--- a/embedded/OH4_Left_Console/4A2A1-LDG_GEAR_PANEL/4A2A1-LDG_GEAR_PANEL.ino
+++ b/embedded/OH4_Left_Console/4A2A1-LDG_GEAR_PANEL/4A2A1-LDG_GEAR_PANEL.ino
@@ -35,7 +35,7 @@
  * @author Arribe
  * @date 2/28/2024
  * @version 0.0.3
- * @copyright Copyright 2016-2024 OpenHornet. Licensed under the Apache License, Version 2.0.
+ * @copyright 2016-2024 OpenHornet. Licensed under the Apache License, Version 2.0.
  * @brief Controls the LDG GEAR panel.
  *
  * @details

--- a/embedded/OH4_Left_Console/4A2A1-LDG_GEAR_PANEL/4A2A1-LDG_GEAR_PANEL.ino
+++ b/embedded/OH4_Left_Console/4A2A1-LDG_GEAR_PANEL/4A2A1-LDG_GEAR_PANEL.ino
@@ -53,16 +53,16 @@
  * 2   | Landing Gear Down Lock Soleniod
  * 3   | Landing Gear Limit Switch (handle raise / lower)
  * 4   | Landing Gear Lollipop LED
- */
-
- /**
+ *
+ *
  * @brief The following #define tells DCS-BIOS that this is a RS-485 slave device.
  * It also sets the address of this slave device. The slave address should be
  * between 1 and 126 and must be unique among all devices on the same bus.
  *
  * @bug Currently does not work with the Pro Micro (32U4), Fails to compile. 
- */
+ *
  // #define DCSBIOS_RS485_SLAVE 1
+*/
 
 /**
  * Check if we're on a Mega328 or Mega2560 and define the correct

--- a/embedded/OH4_Left_Console/4A2A1-LDG_GEAR_PANEL/4A2A1-LDG_GEAR_PANEL.ino
+++ b/embedded/OH4_Left_Console/4A2A1-LDG_GEAR_PANEL/4A2A1-LDG_GEAR_PANEL.ino
@@ -35,7 +35,7 @@
  * @author Arribe
  * @date 2/28/2024
  * @version 0.0.3
- * @copyright 2016-2024 OpenHornet. Licensed under the Apache License, Version 2.0.
+ * @copyright Copyright 2016-2024 OpenHornet. Licensed under the Apache License, Version 2.0.
  * @brief Controls the LDG GEAR panel.
  *
  * @details

--- a/embedded/OH4_Left_Console/4A2A1-LDG_GEAR_PANEL/4A2A1-LDG_GEAR_PANEL.ino
+++ b/embedded/OH4_Left_Console/4A2A1-LDG_GEAR_PANEL/4A2A1-LDG_GEAR_PANEL.ino
@@ -34,7 +34,7 @@
  * @file 4A2A1-LDG_GEAR_PANEL.ino
  * @author Arribe
  * @date 2/28/2024
- * @version 0.0.2
+ * @version 0.0.3
  * @brief Controls the LDG GEAR panel.
  *
  * @details
@@ -53,7 +53,15 @@
  * 3   | Landing Gear Limit Switch (handle raise / lower)
  * 4   | Landing Gear Lollipop LED
  * 
- */
+ *
+ * @brief The following #define tells DCS-BIOS that this is a RS-485 slave device.
+ * It also sets the address of this slave device. The slave address should be
+ * between 1 and 126 and must be unique among all devices on the same bus.
+ *
+ * @bug Currently does not work with the Pro Micro (32U4), Fails to compile. 
+
+   #define DCSBIOS_RS485_SLAVE 1 ///DCSBios RS485 Bus Address, once bug resolved move line below comment.
+*/
 
 /**
  * Check if we're on a Mega328 or Mega2560 and define the correct
@@ -71,94 +79,65 @@
 #endif
 
 /**
- * @brief following #define tells DCS-BIOS that this is a RS-485 slave device.
- * It also sets the address of this slave device. The slave address should be
- * between 1 and 126 and must be unique among all devices on the same bus.
- *
- * @bug Currently does not work with the Pro Micro (32U4), Fails to compile
-*/
-//#define DCSBIOS_RS485_SLAVE 1
-
-/**
  * The Arduino pin that is connected to the
  * RE and DE pins on the RS-485 transceiver.
 */
 #define TXENABLE_PIN 5
 #define UART1_SELECT
 
-/**
- * DCS Bios library include
- */
 #include "DcsBios.h"
 
-/**
- * @brief Define Control I/O for DCS-BIOS. 
- * 
- */
-const int lgEmergSw = A1;
-const int lgOrideSw = A2;
-const int lgWarnSw =  A3;
-const int lgLeverSol = 2;
-const int lgLimitSw = 3;
-const int lgLed = 4;
 
-/**
-* @brief Declare variables for down lock logic
-* initializing values for weight on wheels under a cold / onground start and down lock off.
-*
-*/
-int wowLeft = 1;
-int wowRight = 1;
-int wowNose = 1;
-int downLockOverride = 0;
+// Define pins for DCS-BIOS per interconnect diagram.
+#define LG_EMERG A1
+#define LG_ORIDE A2
+#define LG_WARN A3
+#define LG_LEVER_SOLENOID 2
+#define LG_LIMIT 3
+#define LG_LED 4
 
-/**
- * @brief Connect switches to DCS-BIOS 
- * 
- */
-DcsBios::Switch2Pos emergencyGearRotate("EMERGENCY_GEAR_ROTATE", lgEmergSw);
-DcsBios::Switch2Pos gearDownlockOverrideBtn("GEAR_DOWNLOCK_OVERRIDE_BTN", lgOrideSw);
-DcsBios::Switch2Pos gearLever("GEAR_LEVER", lgLimitSw);
-DcsBios::Switch2Pos gearSilenceBtn("GEAR_SILENCE_BTN", lgWarnSw);
-DcsBios::LED landingGearHandleLt(0x747e, 0x0800, lgLed);
+//Declare variables for down lock logic
+bool wowLeft = true;           ///< Initializing weight-on-wheel value for cold/ground start.
+bool wowRight = true;          ///< Initializing weight-on-wheel value for cold/ground start.
+bool wowNose = true;           ///< Initializing weight-on-wheel value for cold/ground start.
+bool downLockOverride = false; ///< Initializing value for down lock override to not pressed.
 
-/**
-* @brief DCSBios reads to save airplane state information.
-*
-*/
+// Connect switches to DCS-BIOS 
+DcsBios::Switch2Pos emergencyGearRotate("EMERGENCY_GEAR_ROTATE", LG_EMERG);
+DcsBios::Switch2Pos gearDownlockOverrideBtn("GEAR_DOWNLOCK_OVERRIDE_BTN", LG_ORIDE);
+DcsBios::Switch2Pos gearLever("GEAR_LEVER", LG_LIMIT);
+DcsBios::Switch2Pos gearSilenceBtn("GEAR_SILENCE_BTN", LG_WARN);
+DcsBios::LED landingGearHandleLt(0x747e, 0x0800, LG_LED);
+
+// DCSBios reads to save airplane state information.
 void onExtWowLeftChange(unsigned int newValue) {
   wowLeft = newValue;
-}
-DcsBios::IntegerBuffer extWowLeftBuffer(0x74d8, 0x0100, 8, onExtWowLeftChange);
+} DcsBios::IntegerBuffer extWowLeftBuffer(0x74d8, 0x0100, 8, onExtWowLeftChange);
 
 void onExtWowNoseChange(unsigned int newValue) {
   wowNose = newValue;
-}
-DcsBios::IntegerBuffer extWowNoseBuffer(0x74d6, 0x4000, 14, onExtWowNoseChange);
+} DcsBios::IntegerBuffer extWowNoseBuffer(0x74d6, 0x4000, 14, onExtWowNoseChange);
 
 void onExtWowRightChange(unsigned int newValue) {
   wowRight = newValue;
-}
-DcsBios::IntegerBuffer extWowRightBuffer(0x74d6, 0x8000, 15, onExtWowRightChange);
+} DcsBios::IntegerBuffer extWowRightBuffer(0x74d6, 0x8000, 15, onExtWowRightChange);
 
 void onGearDownlockOverrideBtnChange(unsigned int newValue) {
   downLockOverride = newValue;
-}
-DcsBios::IntegerBuffer gearDownlockOverrideBtnBuffer(0x747e, 0x4000, 14, onGearDownlockOverrideBtnChange);
+} DcsBios::IntegerBuffer gearDownlockOverrideBtnBuffer(0x747e, 0x4000, 14, onGearDownlockOverrideBtnChange);
 
 /**
 * Arduino Setup Function
 *
-* Arduino standard Setup Function. Code who should be executed
-* only once at the programm start, belongs in this function.
+* Code that should be executed only once at the programm start, belongs in this function.
 */
 void setup() {
 
   // Run DCS Bios setup function
   DcsBios::setup();
 
-  pinMode(lgLeverSol, OUTPUT);
-  digitalWrite(lgLeverSol, LOW);  //initialize solenoid to off
+  pinMode(LG_LEVER_SOLENOID, OUTPUT);
+  digitalWrite(LG_LEVER_SOLENOID, LOW);  //initialize solenoid to off
 }
 
 /**
@@ -173,23 +152,24 @@ void loop() {
   DcsBios::loop();
 
 /**
-* If landing gear handle in down position and lock override pushed, then activate soleniod to unlock handle.
-* If landing gear handle in down position and NO weight on wheels, then activate soleniod to unlock handle.
-* IF landing gear handle is down and there is weight on at least one wheel, then turn off soleniod to lock handle down.
-* If landing gear handle is up turn off soleniod, handle cannot be locked in up position.
-* 
-* Note: digital reads of switch state will allow the landing gear handle to operate using the downlock override button
-* without needing to have the sim running.
+ ### Landing Gear Down Lock Logic
+*  -# If landing gear handle in down position and lock override pushed, then activate soleniod to **unlock** handle. \n
+*  -# If landing gear handle in down position and NO weight on wheels, then activate soleniod to **unlock** handle. \n
+*  -# IF landing gear handle is down and there is weight on at least one wheel, then turn off soleniod to **lock** handle down. \n
+*  -# If landing gear handle is up turn off soleniod, handle cannot physically be locked in up position. \n
+*  \n
+* *Note: digital reads of switch state will allow the landing gear handle to operate using the downlock override button
+* without needing to have the sim running*.
 */
-  if (digitalRead(lgLimitSw) == 1) {  //Switch closed, gear handle is down
-    if (downLockOverride == 1 || !digitalRead(lgOrideSw) == 1) {  // Override switched pushed virually in sim or physcially in pit, turn on soleniod to unlock gear handle.
-      digitalWrite(lgLeverSol, HIGH);
-    } else if (wowLeft == wowRight == wowNose == 0) {  //No weight on any wheel, turn on soleniod to unlock the gear handle
-      digitalWrite(lgLeverSol, HIGH);
+  if (digitalRead(LG_LIMIT) == 1) {                              //Switch closed, gear handle is down
+    if (downLockOverride == true || !digitalRead(LG_ORIDE) == true) {  // Override switched pushed virually in sim or physcially in pit, turn on soleniod to unlock gear handle.
+      digitalWrite(LG_LEVER_SOLENOID, HIGH);
+    } else if (wowLeft == wowRight == wowNose == false) {  //No weight on any wheel, turn on soleniod to unlock the gear handle
+      digitalWrite(LG_LEVER_SOLENOID, HIGH);
     } else {  // gear handle is down and there is weight on at least one wheel, turn off soleniod to lock the handle down.
-      digitalWrite(lgLeverSol, LOW);
+      digitalWrite(LG_LEVER_SOLENOID, LOW);
     }
   } else {  //gear handle up, turn off soleniod
-    digitalWrite(lgLeverSol, LOW);
+    digitalWrite(LG_LEVER_SOLENOID, LOW);
   }
 }

--- a/embedded/OH4_Left_Console/4A2A1-LDG_GEAR_PANEL/4A2A1-LDG_GEAR_PANEL.ino
+++ b/embedded/OH4_Left_Console/4A2A1-LDG_GEAR_PANEL/4A2A1-LDG_GEAR_PANEL.ino
@@ -35,6 +35,7 @@
  * @author Arribe
  * @date 2/28/2024
  * @version 0.0.3
+ * @copyright Copyright 2016-2024 OpenHornet. Licensed under the Apache License, Version 2.0.
  * @brief Controls the LDG GEAR panel.
  *
  * @details
@@ -43,7 +44,7 @@
  *  * **Intended Board:** ABSIS ALE /w Relay Module
  *  * **RS485 Bus Address:** 1
  * 
- * **Wiring diagram:**
+ * ### Wiring diagram:
  * PIN | Function
  * --- | ---
  * A1  | Landing Gear Emergency Rotate and Pull
@@ -52,26 +53,25 @@
  * 2   | Landing Gear Down Lock Soleniod
  * 3   | Landing Gear Limit Switch (handle raise / lower)
  * 4   | Landing Gear Lollipop LED
- * 
- *
+ */
+
+ /**
  * @brief The following #define tells DCS-BIOS that this is a RS-485 slave device.
  * It also sets the address of this slave device. The slave address should be
  * between 1 and 126 and must be unique among all devices on the same bus.
  *
  * @bug Currently does not work with the Pro Micro (32U4), Fails to compile. 
-
-   #define DCSBIOS_RS485_SLAVE 1 ///DCSBios RS485 Bus Address, once bug resolved move line below comment.
-*/
+ */
+ // #define DCSBIOS_RS485_SLAVE 1
 
 /**
  * Check if we're on a Mega328 or Mega2560 and define the correct
  * serial interface
- * 
  */
 #if defined(__AVR_ATmega328P__) || defined(__AVR_ATmega2560__)
-#define DCSBIOS_IRQ_SERIAL
+#define DCSBIOS_IRQ_SERIAL ///< This enables interrupt-driven serial communication for DCS-BIOS. (Only used with the ATmega328P or ATmega2560 microcontrollers.)
 #else
-#define DCSBIOS_DEFAULT_SERIAL
+#define DCSBIOS_DEFAULT_SERIAL ///< This enables the default serial communication for DCS-BIOS. (Used with all other microcontrollers than the ATmega328P or ATmega2560.)  
 #endif
 
 #ifdef __AVR__
@@ -82,19 +82,19 @@
  * The Arduino pin that is connected to the
  * RE and DE pins on the RS-485 transceiver.
 */
-#define TXENABLE_PIN 5
-#define UART1_SELECT
+#define TXENABLE_PIN 5 ///< Sets TXENABLE_PIN to Arduino Pin 5
+#define UART1_SELECT ///< Selects UART1 on Arduino for serial communication
 
 #include "DcsBios.h"
 
 
 // Define pins for DCS-BIOS per interconnect diagram.
-#define LG_EMERG A1
-#define LG_ORIDE A2
-#define LG_WARN A3
-#define LG_LEVER_SOLENOID 2
-#define LG_LIMIT 3
-#define LG_LED 4
+#define LG_EMERG A1 ///< Landing Gear Emergency Rotate and Pull
+#define LG_ORIDE A2 ///< Landing Gear Down Lock Override Button
+#define LG_WARN A3 ///< Landing Gear Warning Silence Button
+#define LG_LEVER_SOLENOID 2 ///< Landing Gear Down Lock Soleniod
+#define LG_LIMIT 3 ///< Landing Gear Limit Switch (handle raise / lower)
+#define LG_LED 4 ///< Landing Gear Lollipop LED
 
 //Declare variables for down lock logic
 bool wowLeft = true;           ///< Initializing weight-on-wheel value for cold/ground start.
@@ -152,14 +152,14 @@ void loop() {
   DcsBios::loop();
 
 /**
- ### Landing Gear Down Lock Logic
+* ### Landing Gear Down Lock Logic
 *  -# If landing gear handle in down position and lock override pushed, then activate soleniod to **unlock** handle. \n
 *  -# If landing gear handle in down position and NO weight on wheels, then activate soleniod to **unlock** handle. \n
 *  -# IF landing gear handle is down and there is weight on at least one wheel, then turn off soleniod to **lock** handle down. \n
 *  -# If landing gear handle is up turn off soleniod, handle cannot physically be locked in up position. \n
 *  \n
-* *Note: digital reads of switch state will allow the landing gear handle to operate using the downlock override button
-* without needing to have the sim running*.
+* @remark Digital reads of switch state will allow the landing gear handle to operate using the downlock override button
+* without needing to have the sim running.
 */
   if (digitalRead(LG_LIMIT) == 1) {                              //Switch closed, gear handle is down
     if (downLockOverride == true || !digitalRead(LG_ORIDE) == true) {  // Override switched pushed virually in sim or physcially in pit, turn on soleniod to unlock gear handle.

--- a/embedded/OH4_Left_Console/4A2A1-LDG_GEAR_PANEL/Makefile
+++ b/embedded/OH4_Left_Console/4A2A1-LDG_GEAR_PANEL/Makefile
@@ -1,5 +1,5 @@
 # Any extra libraries included by this sketch (space separated)
-LIBRARIES = Adafruit_NeoPixel Servo dcs-bios-arduino-library
+LIBRARIES = Adafruit_NeoPixel Servo dcs-bios-arduino-library TCA9534
 
 # Uncomment one of the following to choose the target board
 # include ../../include/mega2560.mk


### PR DESCRIPTION
## Description

Updated landing gear panel to clean-up comments and make minor variable type updates from int to bool.

Closes #

### Dependencies
* List any dependencies that are required for this change, including a full list of libraries required, especially if it is a new or otherwise unused library in the OpenHornet software.

### Type of change
- [ ] New software module (new software module for slave)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update outside of the automatically-generated Doxygen documentation.

### Checklist:
- [x] My code follows the [style guidelines](https://jrsteensen.github.io/OpenHornet-Software/d4/d46/md__2github_2workspace_2_s_t_y_l_e_g_u_i_d_e.html) of this project
- [x] [I have complied with the software manual](https://jrsteensen.github.io/OpenHornet-Software/d7/d78/md__software_manual.html) for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code fully with Doxygen compatible comments, particularly in hard-to-understand areas
- [x] I have made corresponding changes to non-Doxygen generated documentation
- [x] I have ran Doxygen locally, and it builds the docs successfully
- [x] My changes generate no errors on compile in Arduino IDE
- [x] My changes generate no new warnings on compile in Arduino IDE
- [x] Any dependent changes have been merged and published in downstream modules
- [x] (For sketches only) This sketch complies with OH-INTERCONNECT v**10**
- [ ] If this sketch requires additional libraries, [I have added it as a sub-module per the Arduino Libraries section of the Software Manual.](https://jrsteensen.github.io/OpenHornet-Software/d7/d78/md__software_manual.html)

### How Has This Been Tested?

- [ ] I have tested the sketch in-circuit in DCS with DCS-BIOS and outputs (displays, LEDs, etc.) function as expected. 
- [ ] I have tested the sketch in-circuit in DCS with DCS-BIOS and HID inputs (switches, pots, etc.) function as expected, with switches moving the correct direction.
- [x] I have tested the sketch in-circuit in DCS with DCS-BIOS and any logic in the sketch has been tested and functions as expected.
- [ ] This code has not yet been tested in-circuit.
- [ ] This code has not yet been tested in DCS-BIOS.

#### Description of Testing
Ran tests with and without DCS running to ensure that the DCS Bios messages were as expected, and that the down lock override works outside of DCS.  Ran tests within DCS to ensure that the down lock logic works correctly.

#### Test Configuration
* Firmware version:
* Hardware:
* Toolchain:
* SDK: