### PR TITLE
refactored-1A2-MASTER_ARM_PANEL

### DIFF
--- a/embedded/OH1_Upper_Instrument_Panel/1A2-MASTER_ARM_PANEL/1A2-MASTER_ARM_PANEL.ino
+++ b/embedded/OH1_Upper_Instrument_Panel/1A2-MASTER_ARM_PANEL/1A2-MASTER_ARM_PANEL.ino
@@ -32,11 +32,11 @@
 
 /**
  * @file 1A2-MASTER_ARM_PANEL.ino
- * @author Sandra Carroll (<a href="mailto:smgvbest@gmail.com">smgvbest@gmail.com</a>)
- * @date 27.12.2022
- * @version u.0.0.1 (untested)
- * @warning This sketch is based on a wiring diagram, and was not yet tested on hardware.
- * @brief ABSIS ALE MASTER ARM, RS485 BUS ADDRESS 1 
+ * @author Sandra Carroll (<a href="mailto:smgvbest@gmail.com">smgvbest@gmail.com</a>), Arribe
+ * @date 3.02.2024
+ * @version 0.0.2
+ * @copyright Copyright 2016-2024 OpenHornet. Licensed under the Apache License, Version 2.0.
+ * @brief Controls the MASTER ARM panel. 
  *
  * @details This sketch is for the UIP Master Arm Panel.
  * 
@@ -44,7 +44,7 @@
  *  * **Intended Board:** ABSIS ALE
  *  * **RS485 Bus Address:** 1
  *  
- * **Wiring diagram:**
+ * ###Wiring diagram:
  * 
  * PIN | Function
  * --- | ---
@@ -53,7 +53,14 @@
  * A3  | Ready/Discharge Switch
  * D2  | Air to Air Select
  * D3  | Master Arm Switch
- * D5  | TXENABLE_PIN for RS485 Communications
+ *
+ *  
+ * @brief The following #define tells DCS-BIOS that this is a RS-485 slave device.
+ * It also sets the address of this slave device. The slave address should be
+ * between 1 and 126 and must be unique among all devices on the same bus.
+ *
+ * @bug Currently does not work with the Pro Micro (32U4), Fails to compile. 
+ *   #define DCSBIOS_RS485_SLAVE 1 ///DCSBios RS485 Bus Address, once bug resolved move line below comment.
  */
 
 /**
@@ -62,9 +69,9 @@
  * 
  */
 #if defined(__AVR_ATmega328P__) || defined(__AVR_ATmega2560__)
-  #define DCSBIOS_IRQ_SERIAL
+#define DCSBIOS_IRQ_SERIAL ///< This enables interrupt-driven serial communication for DCS-BIOS. (Only used with the ATmega328P or ATmega2560 microcontrollers.)
 #else
-  #define DCSBIOS_DEFAULT_SERIAL
+#define DCSBIOS_DEFAULT_SERIAL ///< This enables the default serial communication for DCS-BIOS. (Used with all other microcontrollers than the ATmega328P or ATmega2560.)  
 #endif
 
 #ifdef __AVR__
@@ -72,102 +79,27 @@
 #endif
 
 /**
- * @brief following #define tells DCS-BIOS that this is a RS-485 slave device.
- * It also sets the address of this slave device. The slave address should be
- * between 1 and 126 and must be unique among all devices on the same bus.
- *
- * @bug Currently does not work with the Pro Micro (32U4), Fails to compile
-*/
-//#define DCSBIOS_RS485_SLAVE 1
-
-/**
  * The Arduino pin that is connected to the
  * RE and DE pins on the RS-485 transceiver.
 */
-#define TXENABLE_PIN        5
-#define UART1_SELECT
+#define TXENABLE_PIN 5 ///< Sets TXENABLE_PIN to Arduino Pin 5
+#define UART1_SELECT ///< Selects UART1 on Arduino for serial communication
 
-/**
- * @brief DCS Bios library include
- */
 #include "DcsBios.h"
 
-/**
- * @brief Define Control I/O for DCS-BIOS 
- * 
- */
-#define e_jett_sw     A1
-#define ag_sw         A2
-#define ready_sw      A3
-#define aa_sw         2
-#define mstr_arm_sw   3
+//Declare pins for DCS-BIOS per interconnect diagram.
+#define E_JETT_SW     A1 ///< Emergency Jettison Switch
+#define AG_SW         A2 ///< Air to Ground Select
+#define READY_SW      A3 ///< Ready/Discharge Switch
+#define AA_SW         2 ///< Air to Air Select
+#define MSTR_ARM_SW   3 ///< Master Arm Switch
 
-
-/**
- * @brief Connect switches to DCS-BIOS 
- * 
- */
-DcsBios::Switch2Pos masterArmSw("MASTER_ARM_SW", mstr_arm_sw);
-DcsBios::Switch2Pos masterModeAa("MASTER_MODE_AA", aa_sw);
-DcsBios::Switch2Pos masterModeAg("MASTER_MODE_AG", ag_sw);
-DcsBios::Switch2Pos emerJettBtn("EMER_JETT_BTN", e_jett_sw);
-DcsBios::Switch2Pos fireExtBtn("FIRE_EXT_BTN", ready_sw);
-
-/**
- * @brief The following is for Notes for Backlight/Switch Lighting and will not be called in this code
- * PIXEL ORDER    D29-D32,D7-D27,D4-D6,D28
- * 
- * READY          D29-D30
- * DISCH          D31-D32
- * AA             D6,D28
- * AA_BL          D15
- * AG             D4,D5
- * AG_BL          D16
- * FIRE_EXGTH     D7-D14
- * MSTR_ARM_BL    D17-D22
- * EMERG_JETT_BL  D23-D27
- */
-
-/**
- * @brief When ready_sw is Depressed D31/D32 are lit
- * 
- * @param newValue 
- */
-void onMcDischChange(unsigned int newValue) {
-    /* your code here */
-}
-DcsBios::IntegerBuffer mcDischBuffer(0x740c, 0x4000, 14, onMcDischChange);
-
-/**
- * @brief When aa_sw is Depressed D6/D28 are lit
- * 
- * @param newValue 
- */
-void onMasterModeAaLtChange(unsigned int newValue) {
-    /* your code here */
-}
-DcsBios::IntegerBuffer masterModeAaLtBuffer(0x740c, 0x0200, 9, onMasterModeAaLtChange);
-
-/**
- * @brief When ag_sw is Despressed D4/D5 are lit
- * 
- * @param newValue 
- */
-void onMasterModeAgLtChange(unsigned int newValue) {
-    /* your code here */
-}
-DcsBios::IntegerBuffer masterModeAgLtBuffer(0x740c, 0x0400, 10, onMasterModeAgLtChange);
-
-/**
- * @brief When APU_FIRE_BUTTON is Depressed  
- * 
- * @param newValue 
- */
-void onFireApuLtChange(unsigned int newValue) {
-    /* your code here */
-}
-DcsBios::IntegerBuffer fireApuLtBuffer(0x740c, 0x0004, 2, onFireApuLtChange);
-
+// Connect switches to DCS-BIOS 
+DcsBios::Switch2Pos masterArmSw("MASTER_ARM_SW", MSTR_ARM_SW);
+DcsBios::Switch2Pos masterModeAa("MASTER_MODE_AA", AA_SW);
+DcsBios::Switch2Pos masterModeAg("MASTER_MODE_AG", AG_SW);
+DcsBios::Switch2Pos emerJettBtn("EMER_JETT_BTN", E_JETT_SW);
+DcsBios::Switch2Pos fireExtBtn("FIRE_EXT_BTN", READY_SW);
 
 /**
  * @brief 

--- a/embedded/OH1_Upper_Instrument_Panel/1A2-MASTER_ARM_PANEL/Makefile
+++ b/embedded/OH1_Upper_Instrument_Panel/1A2-MASTER_ARM_PANEL/Makefile
@@ -1,5 +1,5 @@
 # Any extra libraries included by this sketch (space separated)
-LIBRARIES = Adafruit_NeoPixel Servo dcs-bios-arduino-library
+LIBRARIES = Adafruit_NeoPixel Servo dcs-bios-arduino-library TCA9534
 
 # Uncomment one of the following to choose the target board
 # include ../../include/mega2560.mk


### PR DESCRIPTION
## Description

Updated the 1A2-MASTER_ARM_PANEL sketch to the latest style / template, and tested in hardware.

Closes #34 

### Dependencies
* List any dependencies that are required for this change, including a full list of libraries required, especially if it is a new or otherwise unused library in the OpenHornet software.

### Type of change
- [ ] New software module (new software module for slave)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update outside of the automatically-generated Doxygen documentation.

### Checklist:
- [x] My code follows the [style guidelines](https://jrsteensen.github.io/OpenHornet-Software/d4/d46/md__2github_2workspace_2_s_t_y_l_e_g_u_i_d_e.html) of this project
- [x] [I have complied with the software manual](https://jrsteensen.github.io/OpenHornet-Software/d7/d78/md__software_manual.html) for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code fully with Doxygen compatible comments, particularly in hard-to-understand areas
- [x] I have made corresponding changes to non-Doxygen generated documentation
- [x] I have ran Doxygen locally, and it builds the docs successfully
- [x] My changes generate no errors on compile in Arduino IDE
- [x] My changes generate no new warnings on compile in Arduino IDE
- [x] Any dependent changes have been merged and published in downstream modules
- [x] (For sketches only) This sketch complies with OH-INTERCONNECT v**10**
- [ ] If this sketch requires additional libraries, [I have added it as a sub-module per the Arduino Libraries section of the Software Manual.](https://jrsteensen.github.io/OpenHornet-Software/d7/d78/md__software_manual.html)

### How Has This Been Tested?

- [ ] I have tested the sketch in-circuit in DCS with DCS-BIOS and outputs (displays, LEDs, etc.) function as expected. 
- [ ] I have tested the sketch in-circuit in DCS with DCS-BIOS and HID inputs (switches, pots, etc.) function as expected, with switches moving the correct direction.
- [x] I have tested the sketch in-circuit in DCS with DCS-BIOS and any logic in the sketch has been tested and functions as expected.
- [ ] This code has not yet been tested in-circuit.
- [ ] This code has not yet been tested in DCS-BIOS.

#### Description of Testing
Installed sketch, without DCS running validated DCSBios messages were as expected.

With DCS running, validated all switchtes/push-buttons.

#### Test Configuration
* Firmware version:
* Hardware: OH 0.2.0
* Toolchain:
* SDK: DCSBios FP 0.3.9