### PR TITLE
refactor-1A6-SPIN_RCVY_PANEL

### DIFF
--- a/embedded/OH1_Upper_Instrument_Panel/1A6-SPIN_RCVY_PANEL/1A6-SPIN_RCVY_PANEL.ino
+++ b/embedded/OH1_Upper_Instrument_Panel/1A6-SPIN_RCVY_PANEL/1A6-SPIN_RCVY_PANEL.ino
@@ -33,8 +33,9 @@
 /**
  * @file 1A6-SPIN_RCVY_PANEL.ino
  * @author Arribe
- * @date 02.28.2024
- * @version 0.0.2
+ * @date 03.02.2024
+ * @version 0.0.3
+ * @copyright Copyright 2016-2024 OpenHornet. Licensed under the Apache License, Version 2.0.
  * @brief Controls the SPIN RCVY panel.
  *
  * @details
@@ -43,7 +44,7 @@
  *  * **Intended Board:** ABSIS ALE
  *  * **RS485 Bus Address:** 5
  * 
- * **Wiring diagram:**
+ * ##Wiring diagram:
  * PIN | Function
  * --- | ---
  * A3   | HMD Brightness
@@ -51,6 +52,13 @@
  * D2   | IR Override
  * D3   | Spin Recovery, with cover
  *
+ * @brief The following #define tells DCS-BIOS that this is a RS-485 slave device.
+ * It also sets the address of this slave device. The slave address should be
+ * between 1 and 126 and must be unique among all devices on the same bus.
+ *
+ * @bug Currently does not work with the Pro Micro (32U4), Fails to compile. 
+ *
+ *  #define DCSBIOS_RS485_SLAVE 1 ///DCSBios RS485 Bus Address, once bug resolved move line below comment.
  */
 
 /**
@@ -59,9 +67,9 @@
  * 
  */
 #if defined(__AVR_ATmega328P__) || defined(__AVR_ATmega2560__)
-#define DCSBIOS_IRQ_SERIAL
+#define DCSBIOS_IRQ_SERIAL ///< This enables interrupt-driven serial communication for DCS-BIOS. (Only used with the ATmega328P or ATmega2560 microcontrollers.)
 #else
-#define DCSBIOS_DEFAULT_SERIAL
+#define DCSBIOS_DEFAULT_SERIAL ///< This enables the default serial communication for DCS-BIOS. (Used with all other microcontrollers than the ATmega328P or ATmega2560.)  
 #endif
 
 #ifdef __AVR__
@@ -69,42 +77,24 @@
 #endif
 
 /**
- * @brief following #define tells DCS-BIOS that this is a RS-485 slave device.
- * It also sets the address of this slave device. The slave address should be
- * between 1 and 126 and must be unique among all devices on the same bus.
- *
- * @bug Currently does not work with the Pro Micro (32U4), Fails to compile
-*/
-//#define DCSBIOS_RS485_SLAVE 5
-
-/**
  * The Arduino pin that is connected to the
  * RE and DE pins on the RS-485 transceiver.
 */
-#define TXENABLE_PIN 5
-#define UART1_SELECT
+#define TXENABLE_PIN 5 ///< Sets TXENABLE_PIN to Arduino Pin 5
+#define UART1_SELECT ///< Selects UART1 on Arduino for serial communication
 
-/**
- * DCS Bios library include.
- */
 #include "DcsBios.h"
 
-/**
- * @brief Define Control I/O for DCS-BIOS. 
- * 
- */
-const int hmdA = A3;
-const int irOff = A2;
-const int irOride = 2;
-const int spinRcvy = 3;
+// Define pins for DCS-BIOS per interconnect diagram.
+#define HMD_A A3 ///< HMD Brightness
+#define IR_OFF A2 ///< IR Off
+#define IR_ORIDE 2 ///< IR Override
+#define SPIN_RCVY 3 ///< Spin Recovery, with cover
 
-/**
- * @brief Connect switches to DCS-BIOS 
- * 
- */
-DcsBios::Potentiometer hmdOffBrt("HMD_OFF_BRT", hmdA);
-DcsBios::Switch3Pos irCoolSw("IR_COOL_SW", irOride, irOff);
-DcsBios::SwitchWithCover2Pos spinRecoverySw("SPIN_RECOVERY_SW", "SPIN_RECOVERY_COVER", spinRcvy);
+// Connect switches to DCS-BIOS 
+DcsBios::Potentiometer hmdOffBrt("HMD_OFF_BRT", HMD_A);
+DcsBios::Switch3Pos irCoolSw("IR_COOL_SW", IR_ORIDE, IR_OFF);
+DcsBios::SwitchWithCover2Pos spinRecoverySw("SPIN_RECOVERY_SW", "SPIN_RECOVERY_COVER", SPIN_RCVY);
 
 /**
 * Arduino Setup Function

--- a/embedded/OH1_Upper_Instrument_Panel/1A6-SPIN_RCVY_PANEL/Makefile
+++ b/embedded/OH1_Upper_Instrument_Panel/1A6-SPIN_RCVY_PANEL/Makefile
@@ -1,5 +1,5 @@
 # Any extra libraries included by this sketch (space separated)
-LIBRARIES = Adafruit_NeoPixel Servo dcs-bios-arduino-library
+LIBRARIES = Adafruit_NeoPixel Servo dcs-bios-arduino-library TCA9534
 
 # Uncomment one of the following to choose the target board
 # include ../../include/mega2560.mk


### PR DESCRIPTION
## Description

Updated 1A6-SPIN_RCVY_PANEL.ino with the latest style guide for comments and naming standard.

Closes #

### Dependencies
* List any dependencies that are required for this change, including a full list of libraries required, especially if it is a new or otherwise unused library in the OpenHornet software.

### Type of change
- [ ] New software module (new software module for slave)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update outside of the automatically-generated Doxygen documentation.

### Checklist:
- [x] My code follows the [style guidelines](https://jrsteensen.github.io/OpenHornet-Software/d4/d46/md__2github_2workspace_2_s_t_y_l_e_g_u_i_d_e.html) of this project
- [x] [I have complied with the software manual](https://jrsteensen.github.io/OpenHornet-Software/d7/d78/md__software_manual.html) for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code fully with Doxygen compatible comments, particularly in hard-to-understand areas
- [x] I have made corresponding changes to non-Doxygen generated documentation
- [x] I have ran Doxygen locally, and it builds the docs successfully
- [x] My changes generate no errors on compile in Arduino IDE
- [x] My changes generate no new warnings on compile in Arduino IDE
- [x] Any dependent changes have been merged and published in downstream modules
- [x] (For sketches only) This sketch complies with OH-INTERCONNECT v**10**
- [ ] If this sketch requires additional libraries, [I have added it as a sub-module per the Arduino Libraries section of the Software Manual.](https://jrsteensen.github.io/OpenHornet-Software/d7/d78/md__software_manual.html)

### How Has This Been Tested?

- [ ] I have tested the sketch in-circuit in DCS with DCS-BIOS and outputs (displays, LEDs, etc.) function as expected. 
- [ ] I have tested the sketch in-circuit in DCS with DCS-BIOS and HID inputs (switches, pots, etc.) function as expected, with switches moving the correct direction.
- [x] I have tested the sketch in-circuit in DCS with DCS-BIOS and any logic in the sketch has been tested and functions as expected.
- [ ] This code has not yet been tested in-circuit.
- [ ] This code has not yet been tested in DCS-BIOS.

#### Description of Testing
Tested the sketch while DCS was running to verify switches moved as expected.

#### Test Configuration
* Firmware version: 
* Hardware: OH 0.2.0
* Toolchain:
* SDK: DCSBios 0.3.9