### PR TITLE
Refactor CI; Fix Compilation and Artifact Generation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 *.bak
+.venv/
 .DS_Store
 ~*.*
 doxyHtml
@@ -6,3 +7,4 @@ doc
 html
 docs/html
 release/
+embedded/**/build/

--- a/embedded/Makefile
+++ b/embedded/Makefile
@@ -1,6 +1,9 @@
-MAKEFILES = $(wildcard **/Makefile)
+MAKEFILES = $(wildcard */*/Makefile)
 SKETCHES := $(dir $(MAKEFILES))
+ROOTDIR := $(abspath $(CURDIR)/..)
 RELEASE_DIR := $(abspath $(CURDIR)/../release)
+
+export
 
 all: $(SKETCHES)
 

--- a/embedded/OH1_Upper_Instrument_Panel/1A2-MASTER_ARM_PANEL/Makefile
+++ b/embedded/OH1_Upper_Instrument_Panel/1A2-MASTER_ARM_PANEL/Makefile
@@ -1,8 +1,8 @@
 # Any extra libraries included by this sketch (space separated)
-LIBRARIES = Adafruit_NeoPixel Servo dcs-bios-arduino-library TCA9534
+LIBRARIES = Adafruit_NeoPixel Servo dcs-bios-arduino-library TCA9534 Wire
 
 # Uncomment one of the following to choose the target board
-# include ../../include/mega2560.mk
-include ../../include/promicro.mk
-# include ../../include/promini.mk
-# include ../../include/s2mini.mk
+# include $(ROOTDIR)/include/mega2560.mk
+include $(ROOTDIR)/include/promicro.mk
+# include $(ROOTDIR)/include/promini.mk
+# include $(ROOTDIR)/include/s2mini.mk

--- a/embedded/OH1_Upper_Instrument_Panel/1A3-L_DDI_AND_EWI/Makefile
+++ b/embedded/OH1_Upper_Instrument_Panel/1A3-L_DDI_AND_EWI/Makefile
@@ -1,8 +1,8 @@
 # Any extra libraries included by this sketch (space separated)
-LIBRARIES = Adafruit_NeoPixel Servo dcs-bios-arduino-library TCA9534
+LIBRARIES = Adafruit_NeoPixel Servo dcs-bios-arduino-library TCA9534 Wire
 
 # Uncomment one of the following to choose the target board
-# include ../../include/mega2560.mk
-include ../../include/promicro.mk
-# include ../../include/promini.mk
-# include ../../include/s2mini.mk
+# include $(ROOTDIR)/include/mega2560.mk
+include $(ROOTDIR)/include/promicro.mk
+# include $(ROOTDIR)/include/promini.mk
+# include $(ROOTDIR)/include/s2mini.mk

--- a/embedded/OH1_Upper_Instrument_Panel/1A6-SPIN_RCVY_PANEL/Makefile
+++ b/embedded/OH1_Upper_Instrument_Panel/1A6-SPIN_RCVY_PANEL/Makefile
@@ -1,8 +1,8 @@
 # Any extra libraries included by this sketch (space separated)
-LIBRARIES = Adafruit_NeoPixel Servo dcs-bios-arduino-library TCA9534
+LIBRARIES = Adafruit_NeoPixel Servo dcs-bios-arduino-library TCA9534 Wire
 
 # Uncomment one of the following to choose the target board
-# include ../../include/mega2560.mk
-include ../../include/promicro.mk
-# include ../../include/promini.mk
-# include ../../include/s2mini.mk
+# include $(ROOTDIR)/include/mega2560.mk
+include $(ROOTDIR)/include/promicro.mk
+# include $(ROOTDIR)/include/promini.mk
+# include $(ROOTDIR)/include/s2mini.mk

--- a/embedded/OH1_Upper_Instrument_Panel/1A7-HUD_PANEL/Makefile
+++ b/embedded/OH1_Upper_Instrument_Panel/1A7-HUD_PANEL/Makefile
@@ -1,8 +1,8 @@
 # Any extra libraries included by this sketch (space separated)
-LIBRARIES = Adafruit_NeoPixel Servo dcs-bios-arduino-library TCA9534
+LIBRARIES = Adafruit_NeoPixel Servo dcs-bios-arduino-library TCA9534 Wire
 
 # Uncomment one of the following to choose the target board
-# include ../../include/mega2560.mk
-include ../../include/promicro.mk
-# include ../../include/promini.mk
-# include ../../include/s2mini.mk
+# include $(ROOTDIR)/include/mega2560.mk
+include $(ROOTDIR)/include/promicro.mk
+# include $(ROOTDIR)/include/promini.mk
+# include $(ROOTDIR)/include/s2mini.mk

--- a/embedded/OH3_Center_Tub/3A2A1-SEAT_CONTROLS/Makefile
+++ b/embedded/OH3_Center_Tub/3A2A1-SEAT_CONTROLS/Makefile
@@ -1,8 +1,8 @@
 # Any extra libraries included by this sketch (space separated)
-LIBRARIES = Adafruit_NeoPixel Servo dcs-bios-arduino-library TCA9534 ArduinoJoystickLibrary
+LIBRARIES = Adafruit_NeoPixel Servo dcs-bios-arduino-library TCA9534 Wire ArduinoJoystickLibrary
 
 # Uncomment one of the following to choose the target board
-# include ../../include/mega2560.mk
-include ../../include/promicro.mk
-# include ../../include/promini.mk
-# include ../../include/s2mini.mk
+# include $(ROOTDIR)/include/mega2560.mk
+include $(ROOTDIR)/include/promicro.mk
+# include $(ROOTDIR)/include/promini.mk
+# include $(ROOTDIR)/include/s2mini.mk

--- a/embedded/OH4_Left_Console/4A2A1-LDG_GEAR_PANEL/Makefile
+++ b/embedded/OH4_Left_Console/4A2A1-LDG_GEAR_PANEL/Makefile
@@ -1,8 +1,8 @@
 # Any extra libraries included by this sketch (space separated)
-LIBRARIES = Adafruit_NeoPixel Servo dcs-bios-arduino-library TCA9534
+LIBRARIES = Adafruit_NeoPixel Servo dcs-bios-arduino-library TCA9534 Wire
 
 # Uncomment one of the following to choose the target board
-# include ../../include/mega2560.mk
-include ../../include/promicro.mk
-# include ../../include/promini.mk
-# include ../../include/s2mini.mk
+# include $(ROOTDIR)/include/mega2560.mk
+include $(ROOTDIR)/include/promicro.mk
+# include $(ROOTDIR)/include/promini.mk
+# include $(ROOTDIR)/include/s2mini.mk

--- a/embedded/OH4_Left_Console/4A3A1-SELECT_JETT_PANEL/Makefile
+++ b/embedded/OH4_Left_Console/4A3A1-SELECT_JETT_PANEL/Makefile
@@ -1,8 +1,8 @@
 # Any extra libraries included by this sketch (space separated)
-LIBRARIES = Adafruit_NeoPixel Servo dcs-bios-arduino-library TCA9534
+LIBRARIES = Adafruit_NeoPixel Servo dcs-bios-arduino-library TCA9534 Wire
 
 # Uncomment one of the following to choose the target board
-# include ../../include/mega2560.mk
-include ../../include/promicro.mk
-# include ../../include/promini.mk
-# include ../../include/s2mini.mk
+# include $(ROOTDIR)/include/mega2560.mk
+include $(ROOTDIR)/include/promicro.mk
+# include $(ROOTDIR)/include/promini.mk
+# include $(ROOTDIR)/include/s2mini.mk

--- a/embedded/OH4_Left_Console/4A4A2-EXT_LIGHTS_PANEL/Makefile
+++ b/embedded/OH4_Left_Console/4A4A2-EXT_LIGHTS_PANEL/Makefile
@@ -1,8 +1,8 @@
 # Any extra libraries included by this sketch (space separated)
-LIBRARIES = Adafruit_NeoPixel Servo dcs-bios-arduino-library TCA9534
+LIBRARIES = Adafruit_NeoPixel Servo dcs-bios-arduino-library TCA9534 Wire
 
 # Uncomment one of the following to choose the target board
-# include ../../include/mega2560.mk
-include ../../include/promicro.mk
-# include ../../include/promini.mk
-# include ../../include/s2mini.mk
+# include $(ROOTDIR)/include/mega2560.mk
+include $(ROOTDIR)/include/promicro.mk
+# include $(ROOTDIR)/include/promini.mk
+# include $(ROOTDIR)/include/s2mini.mk

--- a/embedded/OH4_Left_Console/4A5A1-FUEL_PANEL/Makefile
+++ b/embedded/OH4_Left_Console/4A5A1-FUEL_PANEL/Makefile
@@ -1,8 +1,8 @@
 # Any extra libraries included by this sketch (space separated)
-LIBRARIES = Adafruit_NeoPixel Servo dcs-bios-arduino-library TCA9534
+LIBRARIES = Adafruit_NeoPixel Servo dcs-bios-arduino-library TCA9534 Wire
 
 # Uncomment one of the following to choose the target board
-# include ../../include/mega2560.mk
-include ../../include/promicro.mk
-# include ../../include/promini.mk
-# include ../../include/s2mini.mk
+# include $(ROOTDIR)/include/mega2560.mk
+include $(ROOTDIR)/include/promicro.mk
+# include $(ROOTDIR)/include/promini.mk
+# include $(ROOTDIR)/include/s2mini.mk

--- a/embedded/OH4_Left_Console/4A5A2-APU_PANEL/Makefile
+++ b/embedded/OH4_Left_Console/4A5A2-APU_PANEL/Makefile
@@ -1,8 +1,8 @@
 # Any extra libraries included by this sketch (space separated)
-LIBRARIES = Adafruit_NeoPixel Servo dcs-bios-arduino-library TCA9534
+LIBRARIES = Adafruit_NeoPixel Servo dcs-bios-arduino-library TCA9534 Wire
 
 # Uncomment one of the following to choose the target board
-# include ../../include/mega2560.mk
-include ../../include/promicro.mk
-# include ../../include/promini.mk
-# include ../../include/s2mini.mk
+# include $(ROOTDIR)/include/mega2560.mk
+include $(ROOTDIR)/include/promicro.mk
+# include $(ROOTDIR)/include/promini.mk
+# include $(ROOTDIR)/include/s2mini.mk

--- a/embedded/OH4_Left_Console/4A6A1-FCS_PANEL/Makefile
+++ b/embedded/OH4_Left_Console/4A6A1-FCS_PANEL/Makefile
@@ -1,8 +1,8 @@
 # Any extra libraries included by this sketch (space separated)
-LIBRARIES = Adafruit_NeoPixel Servo dcs-bios-arduino-library TCA9534
+LIBRARIES = Adafruit_NeoPixel Servo dcs-bios-arduino-library TCA9534 Wire
 
 # Uncomment one of the following to choose the target board
-# include ../../include/mega2560.mk
-include ../../include/promicro.mk
-# include ../../include/promini.mk
-# include ../../include/s2mini.mk
+# include $(ROOTDIR)/include/mega2560.mk
+include $(ROOTDIR)/include/promicro.mk
+# include $(ROOTDIR)/include/promini.mk
+# include $(ROOTDIR)/include/s2mini.mk

--- a/embedded/OH4_Left_Console/4A7A1-COMM_PANEL/Makefile
+++ b/embedded/OH4_Left_Console/4A7A1-COMM_PANEL/Makefile
@@ -1,8 +1,8 @@
 # Any extra libraries included by this sketch (space separated)
-LIBRARIES = Adafruit_NeoPixel Servo dcs-bios-arduino-library TCA9534
+LIBRARIES = Adafruit_NeoPixel Servo dcs-bios-arduino-library TCA9534 Wire
 
 # Uncomment one of the following to choose the target board
-include ../../include/mega2560.mk
-# include ../../include/promicro.mk
-# include ../../include/promini.mk
-# include ../../include/s2mini.mk
+include $(ROOTDIR)/include/mega2560.mk
+# include $(ROOTDIR)/include/promicro.mk
+# include $(ROOTDIR)/include/promini.mk
+# include $(ROOTDIR)/include/s2mini.mk

--- a/embedded/OH4_Left_Console/4A7A2-OBOGS_PANEL/Makefile
+++ b/embedded/OH4_Left_Console/4A7A2-OBOGS_PANEL/Makefile
@@ -1,8 +1,8 @@
 # Any extra libraries included by this sketch (space separated)
-LIBRARIES = Adafruit_NeoPixel Servo dcs-bios-arduino-library TCA9534
+LIBRARIES = Adafruit_NeoPixel Servo dcs-bios-arduino-library TCA9534 Wire
 
 # Uncomment one of the following to choose the target board
-# include ../../include/mega2560.mk
-include ../../include/promicro.mk
-# include ../../include/promini.mk
-# include ../../include/s2mini.mk
+# include $(ROOTDIR)/include/mega2560.mk
+include $(ROOTDIR)/include/promicro.mk
+# include $(ROOTDIR)/include/promini.mk
+# include $(ROOTDIR)/include/s2mini.mk

--- a/embedded/OH5_Right_Console/5A10-DEFOG_PANEL/Makefile
+++ b/embedded/OH5_Right_Console/5A10-DEFOG_PANEL/Makefile
@@ -1,8 +1,8 @@
 # Any extra libraries included by this sketch (space separated)
-LIBRARIES = Adafruit_NeoPixel Servo dcs-bios-arduino-library TCA9534 ArduinoJoystickLibrary
+LIBRARIES = Adafruit_NeoPixel Servo dcs-bios-arduino-library TCA9534 Wire ArduinoJoystickLibrary
 
 # Uncomment one of the following to choose the target board
-# include ../../include/mega2560.mk
-include ../../include/promicro.mk
-# include ../../include/promini.mk
-# include ../../include/s2mini.mk
+# include $(ROOTDIR)/include/mega2560.mk
+include $(ROOTDIR)/include/promicro.mk
+# include $(ROOTDIR)/include/promini.mk
+# include $(ROOTDIR)/include/s2mini.mk

--- a/embedded/OH5_Right_Console/5A6A1-INTR_LT_PANEL/Makefile
+++ b/embedded/OH5_Right_Console/5A6A1-INTR_LT_PANEL/Makefile
@@ -1,8 +1,8 @@
 # Any extra libraries included by this sketch (space separated)
-LIBRARIES = Adafruit_NeoPixel Servo dcs-bios-arduino-library TCA9534 ArduinoJoystickLibrary
+LIBRARIES = Adafruit_NeoPixel Servo dcs-bios-arduino-library TCA9534 Wire ArduinoJoystickLibrary
 
 # Uncomment one of the following to choose the target board
-# include ../../include/mega2560.mk
-include ../../include/promicro.mk
-# include ../../include/promini.mk
-# include ../../include/s2mini.mk
+# include $(ROOTDIR)/include/mega2560.mk
+include $(ROOTDIR)/include/promicro.mk
+# include $(ROOTDIR)/include/promini.mk
+# include $(ROOTDIR)/include/s2mini.mk

--- a/embedded/OH5_Right_Console/5A7A1-SNSR_PANEL/Makefile
+++ b/embedded/OH5_Right_Console/5A7A1-SNSR_PANEL/Makefile
@@ -1,8 +1,8 @@
 # Any extra libraries included by this sketch (space separated)
-LIBRARIES = Adafruit_NeoPixel Servo dcs-bios-arduino-library TCA9534 ArduinoJoystickLibrary
+LIBRARIES = Adafruit_NeoPixel Servo dcs-bios-arduino-library TCA9534 Wire ArduinoJoystickLibrary
 
 # Uncomment one of the following to choose the target board
-# include ../../include/mega2560.mk
-include ../../include/promicro.mk
-# include ../../include/promini.mk
-# include ../../include/s2mini.mk
+# include $(ROOTDIR)/include/mega2560.mk
+include $(ROOTDIR)/include/promicro.mk
+# include $(ROOTDIR)/include/promini.mk
+# include $(ROOTDIR)/include/s2mini.mk

--- a/embedded/OH5_Right_Console/5A8A1-SIM_CNTL_PANEL/Makefile
+++ b/embedded/OH5_Right_Console/5A8A1-SIM_CNTL_PANEL/Makefile
@@ -1,8 +1,8 @@
 # Any extra libraries included by this sketch (space separated)
-LIBRARIES = Adafruit_NeoPixel Servo dcs-bios-arduino-library TCA9534 ArduinoJoystickLibrary
+LIBRARIES = Adafruit_NeoPixel Servo dcs-bios-arduino-library TCA9534 Wire ArduinoJoystickLibrary
 
 # Uncomment one of the following to choose the target board
-# include ../../include/mega2560.mk
-include ../../include/promicro.mk
-# include ../../include/promini.mk
-# include ../../include/s2mini.mk
+# include $(ROOTDIR)/include/mega2560.mk
+include $(ROOTDIR)/include/promicro.mk
+# include $(ROOTDIR)/include/promini.mk
+# include $(ROOTDIR)/include/s2mini.mk

--- a/embedded/OH5_Right_Console/5A9A1-KY58_PANEL/Makefile
+++ b/embedded/OH5_Right_Console/5A9A1-KY58_PANEL/Makefile
@@ -1,8 +1,8 @@
 # Any extra libraries included by this sketch (space separated)
-LIBRARIES = Adafruit_NeoPixel Servo dcs-bios-arduino-library TCA9534 ArduinoJoystickLibrary
+LIBRARIES = Adafruit_NeoPixel Servo dcs-bios-arduino-library TCA9534 Wire ArduinoJoystickLibrary
 
 # Uncomment one of the following to choose the target board
-# include ../../include/mega2560.mk
-include ../../include/promicro.mk
-# include ../../include/promini.mk
-# include ../../include/s2mini.mk
+# include $(ROOTDIR)/include/mega2560.mk
+include $(ROOTDIR)/include/promicro.mk
+# include $(ROOTDIR)/include/promini.mk
+# include $(ROOTDIR)/include/s2mini.mk

--- a/embedded/templates/OHSketchTemplate/Makefile
+++ b/embedded/templates/OHSketchTemplate/Makefile
@@ -1,8 +1,8 @@
 # Any extra libraries included by this sketch (space separated)
-LIBRARIES = Adafruit_NeoPixel Servo dcs-bios-arduino-library TCA9534 ArduinoJoystickLibrary
+LIBRARIES = Adafruit_NeoPixel Servo dcs-bios-arduino-library TCA9534 Wire ArduinoJoystickLibrary
 
 # Uncomment one of the following to choose the target board
-# include ../../include/mega2560.mk
-include ../../include/promicro.mk
-# include ../../include/promini.mk
-# include ../../include/s2mini.mk
+# include $(ROOTDIR)/include/mega2560.mk
+include $(ROOTDIR)/include/promicro.mk
+# include $(ROOTDIR)/include/promini.mk
+# include $(ROOTDIR)/include/s2mini.mk

--- a/include/avr.mk
+++ b/include/avr.mk
@@ -3,6 +3,7 @@ OBJDIR             = build
 # Set the compiled firmware filename to the directory name (OpenHornet component name)
 TARGET             = $(notdir $(CURDIR))
 ARDUINO_SKETCHBOOK = $(ROOTDIR)
+ARDUINO_VERSION    = 10819
 ARDMK_DIR          = $(ROOTDIR)/include/Arduino-Makefile
 ARDUINO_LIBS       = $(LIBRARIES)
 

--- a/include/avr.mk
+++ b/include/avr.mk
@@ -2,11 +2,11 @@
 OBJDIR             = build
 # Set the compiled firmware filename to the directory name (OpenHornet component name)
 TARGET             = $(notdir $(CURDIR))
-ARDUINO_SKETCHBOOK = $(dir $(realpath $(CURDIR)/..))
-ARDMK_DIR          = $(dir $(realpath $(CURDIR)/..))include/Arduino-Makefile
+ARDUINO_SKETCHBOOK = $(ROOTDIR)
+ARDMK_DIR          = $(ROOTDIR)/include/Arduino-Makefile
 ARDUINO_LIBS       = $(LIBRARIES)
 
-include $(dir $(realpath $(CURDIR)/..))include/openhornet.mk
+include $(ROOTDIR)/include/openhornet.mk
 include $(ARDMK_DIR)/Arduino.mk
 
 release: all

--- a/include/esp.mk
+++ b/include/esp.mk
@@ -1,10 +1,10 @@
 ifndef ESP_ROOT
 # Path to the ESP32 Arduino core.
-ESP_ROOT = $(dir $(realpath $(CURDIR)/..))libraries/arduino-esp32
+ESP_ROOT = $(ROOTDIR)/libraries/arduino-esp32
 endif
 
-LIBRARY_DIR        = $(dir $(realpath $(CURDIR)/..))libraries
-ESPMK_DIR          = $(dir $(realpath $(CURDIR)/..))include/makeEspArduino
+LIBRARY_DIR        = $(ROOTDIR)/libraries
+ESPMK_DIR          = $(ROOTDIR)/include/makeEspArduino
 # Include libraries from the libraries directory for linking.
 CUSTOM_LIBS        = $(LIBRARY_DIR)
 # Exclude platform libraries to avoid compilation and linking errors.
@@ -18,7 +18,7 @@ MAIN_NAME          = $(notdir $(CURDIR))
 # Override them so that the debug build output doesn't fail.
 BUILD_EXTRA_FLAGS  = -DARDUINO_HOST_OS=\"linux\" -DARDUINO_FQBN=\"esp32:esp32:esp32s2\"
 
-include $(dir $(realpath $(CURDIR)/..))include/openhornet.mk
+include $(ROOTDIR)/include/openhornet.mk
 include $(ESPMK_DIR)/makeEspArduino.mk
 
 

--- a/include/mega2560.mk
+++ b/include/mega2560.mk
@@ -1,4 +1,4 @@
 BOARD_TAG = mega
 BOARD_SUB = atmega2560
 
-include $(dir $(realpath $(CURDIR)/..))include/avr.mk
+include $(ROOTDIR)/include/avr.mk

--- a/include/openhornet.mk
+++ b/include/openhornet.mk
@@ -1,1 +1,1 @@
-RELEASE_DIR        = $(dir $(realpath $(CURDIR)/..))release
+RELEASE_DIR        = $(ROOTDIR)/release

--- a/include/promicro.mk
+++ b/include/promicro.mk
@@ -1,5 +1,5 @@
 ifndef PROMICRO_DIR
-PROMICRO_DIR = $(dir $(realpath $(CURDIR)/..))libraries/Arduino_Boards/sparkfun
+PROMICRO_DIR = $(ROOTDIR)/libraries/Arduino_Boards/sparkfun
 endif
 
 ALTERNATE_CORE      = promicro
@@ -14,4 +14,4 @@ BOOTLOADER_FILE     = Caterina-promicro16.hex
 ISP_PROG            = usbasp
 USB_PID             = 0x9206
 
-include $(dir $(realpath $(CURDIR)/..))include/avr.mk
+include $(ROOTDIR)/include/avr.mk

--- a/include/promini.mk
+++ b/include/promini.mk
@@ -1,4 +1,4 @@
 BOARD_TAG           = pro
 BOARD_SUB           = 8MHzatmega328
 
-include $(dir $(realpath $(CURDIR)/..))include/avr.mk
+include $(ROOTDIR)/include/avr.mk

--- a/include/s2mini.mk
+++ b/include/s2mini.mk
@@ -1,3 +1,3 @@
 BOARD     = lolin_s2_mini
 
-include $(dir $(realpath $(CURDIR)/..))include/esp.mk
+include $(ROOTDIR)/include/esp.mk


### PR DESCRIPTION
## Description

Several updates to streamline and simplify the directory handling of the Arduino code generation.
Makefiles include from the two-level directory structure in embedded (ie: `embedded/OH1_Upper_Onstrument_Panel/1A2-MASTER_ARM_PANEL`)
Add Wire as a dependency for all TCA9534 projects
Specify the Arduino version to prevent issues with the IDE detection and conflicts with the Arduino Joystick Library

### Dependencies
* None

### Type of change
- [ ] New software module (new software module for slave)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update outside of the automatically-generated Doxygen documentation.