### PR TITLE
Bug fix 5A6A1-INTR_LT_PANEL

### DIFF
--- a/embedded/OH5_Right_Console/5A6A1-INTR_LT_PANEL/5A6A1-INTR_LT_PANEL.ino
+++ b/embedded/OH5_Right_Console/5A6A1-INTR_LT_PANEL/5A6A1-INTR_LT_PANEL.ino
@@ -52,9 +52,9 @@
  * 3   | Day Mode
  * A2  | Warning / Caution Brightness
  * A1  | Chart Brightness
- * 6   | Console Brightness
+ * A7   | Console Brightness
  * 8   | Intrument Panel Brightness
- * 10  | Flood Brightness
+ * A10  | Flood Brightness
  * 
  * @brief The following #define tells DCS-BIOS that this is a RS-485 slave device.
  * It also sets the address of this slave device. The slave address should be

--- a/embedded/OH5_Right_Console/5A6A1-INTR_LT_PANEL/5A6A1-INTR_LT_PANEL.ino
+++ b/embedded/OH5_Right_Console/5A6A1-INTR_LT_PANEL/5A6A1-INTR_LT_PANEL.ino
@@ -95,9 +95,9 @@
 #define DAY 3        ///< Day Mode
 #define WAR_CAUT A2  ///< Warning / Caution Brightness
 #define CHART A1     ///< Chart Brightness
-#define CONSOLES 6   ///< Console Brightness
+#define CONSOLES A7   ///< Console Brightness
 #define INST_PNL 8   ///< Intrument Panel Brightness
-#define FLOOD 10     ///< Flood Brightness
+#define FLOOD A10     ///< Flood Brightness
 
 // Connect switches to DCS-BIOS
 DcsBios::Potentiometer chartDimmer("CHART_DIMMER", CHART);


### PR DESCRIPTION
## Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.

Bug fix for console and flood pots on 5A6A1-INTR_LT_PANEL.  Updated defines to use A# values vs digital pin numbers.

Closes #110 

### Dependencies
* List any dependencies that are required for this change, including a full list of libraries required, especially if it is a new or otherwise unused library in the OpenHornet software.

### Type of change
- [ ] New software module (new software module for slave)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update outside of the automatically-generated Doxygen documentation.

### Checklist:
- [x] My code follows the [style guidelines](https://jrsteensen.github.io/OpenHornet-Software/d4/d46/md__2github_2workspace_2_s_t_y_l_e_g_u_i_d_e.html) of this project
- [x] [I have complied with the software manual](https://jrsteensen.github.io/OpenHornet-Software/d7/d78/md__software_manual.html) for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code fully with Doxygen compatible comments, particularly in hard-to-understand areas
- [x] I have made corresponding changes to non-Doxygen generated documentation
- [x] I have ran Doxygen locally, and it builds the docs successfully
- [ ] My changes generate no errors on compile in Arduino IDE
- [ ] My changes generate no new warnings on compile in Arduino IDE
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] (For sketches only) This sketch complies with OH-INTERCONNECT v**<insert version number here>**
- [ ] If this sketch requires additional libraries, [I have added it as a sub-module per the Arduino Libraries section of the Software Manual.](https://jrsteensen.github.io/OpenHornet-Software/d7/d78/md__software_manual.html)

### How Has This Been Tested?

- [X] I have tested the sketch in-circuit in DCS with DCS-BIOS and outputs (displays, LEDs, etc.) function as expected. 
- [X] I have tested the sketch in-circuit in DCS with DCS-BIOS and HID inputs (switches, pots, etc.) function as expected, with switches moving the correct direction.
- [X] I have tested the sketch in-circuit in DCS with DCS-BIOS and any logic in the sketch has been tested and functions as expected.
- [ ] This code has not yet been tested in-circuit.
- [ ] This code has not yet been tested in DCS-BIOS.

#### Description of Testing
Loaded the sketch and validated the dcsbios messages.

#### Test Configuration
* Firmware version:
* Hardware:
* Toolchain:
* SDK: