### PR TITLE
Update 5A10-DEFOG_PANEL.ino

### DIFF
--- a/embedded/OH5_Right_Console/5A10-DEFOG_PANEL/5A10-DEFOG_PANEL.ino
+++ b/embedded/OH5_Right_Console/5A10-DEFOG_PANEL/5A10-DEFOG_PANEL.ino
@@ -49,7 +49,7 @@
  * PIN | Function
  * --- | ---
  * 15  | Defog - Anti-ice
- * 6   | Defog Lever Potentiometer
+ * A7   | Defog Lever Potentiometer
  * 14  | Defog - Rain 
  * 7   | Canopy Open
  * 16  | Canopy Close
@@ -101,7 +101,7 @@
 
 // Define pins for DCS-BIOS per interconnect diagram.
 #define DF_ANTIICE 15  ///< Defog - Anti-ice
-#define DF_A A0         ///< 6 Defog Lever Potentiometer
+#define DF_A A7         ///< 6 Defog Lever Potentiometer
 #define DF_RAIN 14     ///< Defog - Rain
 #define CN_OPEN 7      ///< Canopy Open
 #define CN_CLOSE 16    ///< Canopy Close


### PR DESCRIPTION
## Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.

Updated defog lever to follow the interconnect diagram setting to A7.

Closes #

### Dependencies
* List any dependencies that are required for this change, including a full list of libraries required, especially if it is a new or otherwise unused library in the OpenHornet software.

### Type of change
- [ ] New software module (new software module for slave)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update outside of the automatically-generated Doxygen documentation.

### Checklist:
- [x] My code follows the [style guidelines](https://jrsteensen.github.io/OpenHornet-Software/d4/d46/md__2github_2workspace_2_s_t_y_l_e_g_u_i_d_e.html) of this project
- [x] [I have complied with the software manual](https://jrsteensen.github.io/OpenHornet-Software/d7/d78/md__software_manual.html) for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code fully with Doxygen compatible comments, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to non-Doxygen generated documentation
- [ ] I have ran Doxygen locally, and it builds the docs successfully
- [x] My changes generate no errors on compile in Arduino IDE
- [x] My changes generate no new warnings on compile in Arduino IDE
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] (For sketches only) This sketch complies with OH-INTERCONNECT v**10**
- [ ] If this sketch requires additional libraries, [I have added it as a sub-module per the Arduino Libraries section of the Software Manual.](https://jrsteensen.github.io/OpenHornet-Software/d7/d78/md__software_manual.html)

### How Has This Been Tested?

- [x] I have tested the sketch in-circuit in DCS with DCS-BIOS and outputs (displays, LEDs, etc.) function as expected. 
- [ ] I have tested the sketch in-circuit in DCS with DCS-BIOS and HID inputs (switches, pots, etc.) function as expected, with switches moving the correct direction.
- [ ] I have tested the sketch in-circuit in DCS with DCS-BIOS and any logic in the sketch has been tested and functions as expected.
- [ ] This code has not yet been tested in-circuit.
- [ ] This code has not yet been tested in DCS-BIOS.

#### Description of Testing
<Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration>

Compiled the script, without error.  Simple renaming of the define to set DF_A to A7 instead of 6.

#### Test Configuration
* Firmware version:
* Hardware:
* Toolchain:
* SDK: