### PR TITLE
Update 2A3A1-AMPCD.ino

### DIFF
--- a/embedded/OH2_Lower_Instrument_Panel/2A3A1-AMPCD/2A3A1-AMPCD.ino
+++ b/embedded/OH2_Lower_Instrument_Panel/2A3A1-AMPCD/2A3A1-AMPCD.ino
@@ -54,6 +54,7 @@
  * 10  | HDG -
  * 4   | CRS +
  * 7   | CRS -
+ * 9   | DDI Backlighting PWM, must be defined as digital pin #
  * 6   | AMPCD IRQ Pin
  * 
  *
@@ -101,7 +102,7 @@
 #define HDG_M 10             ///< HDG -
 #define CRS_P 4              ///< CRS +
 #define CRS_M 7              ///< CRS -
-#define AMPCD_BACK_LIGHT A9  ///< DDI Backlighting PWM
+#define AMPCD_BACK_LIGHT 9  ///< DDI Backlighting PWM, must be defined as digital pin #
 #define AMPCD_IRQ 6 ///< AMPCD IRQ Pin
 
 /**
@@ -140,8 +141,6 @@ DcsBios::Switch3Pos leftDdiHdgSw("LEFT_DDI_HDG_SW", HDG_P, HDG_M);
 /**
  * @brief Setup DCS-BIOS control for DDI backlighting
  *
- * @bug Potential bug with backlighting, the lights are either full on when DCSBios reports the intensity >50% or full off <50%. May be an electrical / PCB issue.
- * 
  */
 void onInstrIntLtChange(unsigned int newValue) {
   analogWrite(AMPCD_BACK_LIGHT, map(newValue, 0, 65535, 0, 255));


### PR DESCRIPTION
Updated the backlighting pin define to be 9 vs A9 and reported by Howling-Ape

## Description

Fixed Backlighting for the AMPCD.

Closes #

### Dependencies
* List any dependencies that are required for this change, including a full list of libraries required, especially if it is a new or otherwise unused library in the OpenHornet software.

### Type of change
- [ ] New software module (new software module for slave)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update outside of the automatically-generated Doxygen documentation.

### Checklist:
- [X] My code follows the [style guidelines](https://jrsteensen.github.io/OpenHornet-Software/d4/d46/md__2github_2workspace_2_s_t_y_l_e_g_u_i_d_e.html) of this project
- [X] [I have complied with the software manual](https://jrsteensen.github.io/OpenHornet-Software/d7/d78/md__software_manual.html) for this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code fully with Doxygen compatible comments, particularly in hard-to-understand areas
- [X] I have made corresponding changes to non-Doxygen generated documentation
- [X] I have ran Doxygen locally, and it builds the docs successfully
- [X] My changes generate no errors on compile in Arduino IDE
- [X] My changes generate no new warnings on compile in Arduino IDE
- [ ] Any dependent changes have been merged and published in downstream modules
- [X] (For sketches only) This sketch complies with OH-INTERCONNECT v**10**
- [ ] If this sketch requires additional libraries, [I have added it as a sub-module per the Arduino Libraries section of the Software Manual.](https://jrsteensen.github.io/OpenHornet-Software/d7/d78/md__software_manual.html)

### How Has This Been Tested?

- [X] I have tested the sketch in-circuit in DCS with DCS-BIOS and outputs (displays, LEDs, etc.) function as expected. 
- [X] I have tested the sketch in-circuit in DCS with DCS-BIOS and HID inputs (switches, pots, etc.) function as expected, with switches moving the correct direction.
- [X] I have tested the sketch in-circuit in DCS with DCS-BIOS and any logic in the sketch has been tested and functions as expected.
- [ ] This code has not yet been tested in-circuit.
- [ ] This code has not yet been tested in DCS-BIOS.

#### Description of Testing
Loaded sketch and tested the backlighting along with all the button presses in DCS.

#### Test Configuration
* Firmware version:
* Hardware:
* Toolchain:
* SDK: