### PR TITLE
DDI_Backlighting_fix

### DIFF
--- a/embedded/OH1_Upper_Instrument_Panel/1A3-L_DDI_AND_EWI/1A3-L_DDI_AND_EWI.ino
+++ b/embedded/OH1_Upper_Instrument_Panel/1A3-L_DDI_AND_EWI/1A3-L_DDI_AND_EWI.ino
@@ -57,7 +57,7 @@
  * A10 | LDDI Contrast Encoder B
  * 14  | LEWI Fire
  * 16  | LEWI Master Caution 
- * A9  | DDI Backlighting PWM 
+ * 9   | DDI Backlighting PWM, pin must be defined as digital #
  * 6   | DDI IRQ
  * 
  *
@@ -108,7 +108,7 @@
 #define LDDI_CONT_B A10 ///< LDDI Contrast Encoder B
 #define LEWI_FIRE_SW 14 ///< LEWI Fire
 #define LEWI_MC_SW 16 ///< LEWI Master Caution
-#define DDI_BACK_LIGHT A9 ///< DDI Backlighting PWM
+#define DDI_BACK_LIGHT 9 ///< DDI Backlighting PWM, pin must be defined as digital #
 #define DDI_IRQ 6 ///< DDI controller interrupt
 
 /**
@@ -149,8 +149,6 @@ DcsBios::SwitchMultiPos leftDdiBrtSelect("LEFT_DDI_BRT_SELECT", leftDdiBrtSelect
 /**
  * @brief Setup DCS-BIOS control for DDI backlighting
  *
- * @bug Potential bug with backlighting, the lights are either full on when DCSBios reports the intensity >50% or full off <50%. May be an electrical / PCB issue.
- * 
  */
 void onInstrIntLtChange(unsigned int newValue) {
   analogWrite(DDI_BACK_LIGHT, map(newValue, 0, 65535, 0, 255));

--- a/embedded/OH1_Upper_Instrument_Panel/1A9-R_DDI_AND_EWI/1A9-R_DDI_AND_EWI.ino
+++ b/embedded/OH1_Upper_Instrument_Panel/1A9-R_DDI_AND_EWI/1A9-R_DDI_AND_EWI.ino
@@ -57,7 +57,8 @@
  * A10 | RDDI Contrast Encoder B
  * 14  | REWI Fire
  * 16  | REWI Master Caution 
- * A9  | DDI Backlighting PWM 
+ * 9   | DDI Backlighting PWM, pin must be defined as digital #
+ * 6   | DDI Interrupt Pin 
  * 
  *
  * @brief following #define tells DCS-BIOS that this is a RS-485 slave device.
@@ -107,7 +108,7 @@
 #define RDDI_CONT_B A10 ///< RDDI Contrast Encoder B
 #define REWI_FIRE_SW 14 ///< REWI Fire
 #define REWI_MC_SW 16 ///< REWI Master Caution
-#define DDI_BACK_LIGHT A9 ///< DDI Backlighting PWM
+#define DDI_BACK_LIGHT 9 ///< DDI Backlighting PWM, pin must be defined as digital #
 #define DDI_IRQ 6 ///< DDI Interrupt Pin
 
 /**
@@ -148,8 +149,6 @@ DcsBios::SwitchMultiPos rightDdiBrtSelect("RIGHT_DDI_BRT_SELECT", rightDdiBrtSel
 /**
  * @brief Setup DCS-BIOS control for DDI backlighting
  *
- * @bug Potential bug with backlighting, the lights are either full on when DCSBios reports the intensity >50% or full off <50%. May be an electrical / PCB issue.
- * 
  */
 void onInstrIntLtChange(unsigned int newValue) {
   analogWrite(DDI_BACK_LIGHT, map(newValue, 0, 65535, 0, 255));


### PR DESCRIPTION
updated the backlighting pin definition to 9 vs A9 as reported by Howling_Ape

## Description

Fixed the L and R DDI backlighting code so that it dims properly.

Closes #

### Dependencies
* List any dependencies that are required for this change, including a full list of libraries required, especially if it is a new or otherwise unused library in the OpenHornet software.

### Type of change
- [ ] New software module (new software module for slave)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update outside of the automatically-generated Doxygen documentation.

### Checklist:
- [X] My code follows the [style guidelines](https://jrsteensen.github.io/OpenHornet-Software/d4/d46/md__2github_2workspace_2_s_t_y_l_e_g_u_i_d_e.html) of this project
- [X] [I have complied with the software manual](https://jrsteensen.github.io/OpenHornet-Software/d7/d78/md__software_manual.html) for this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code fully with Doxygen compatible comments, particularly in hard-to-understand areas
- [X] I have made corresponding changes to non-Doxygen generated documentation
- [X] I have ran Doxygen locally, and it builds the docs successfully
- [X] My changes generate no errors on compile in Arduino IDE
- [X] My changes generate no new warnings on compile in Arduino IDE
- [ ] Any dependent changes have been merged and published in downstream modules
- [X] (For sketches only) This sketch complies with OH-INTERCONNECT v**10**
- [ ] If this sketch requires additional libraries, [I have added it as a sub-module per the Arduino Libraries section of the Software Manual.](https://jrsteensen.github.io/OpenHornet-Software/d7/d78/md__software_manual.html)

### How Has This Been Tested?

- [X] I have tested the sketch in-circuit in DCS with DCS-BIOS and outputs (displays, LEDs, etc.) function as expected. 
- [ ] I have tested the sketch in-circuit in DCS with DCS-BIOS and HID inputs (switches, pots, etc.) function as expected, with switches moving the correct direction.
- [X] I have tested the sketch in-circuit in DCS with DCS-BIOS and any logic in the sketch has been tested and functions as expected.
- [ ] This code has not yet been tested in-circuit.
- [ ] This code has not yet been tested in DCS-BIOS.

#### Description of Testing
Loaded the sketch to verify the backlighting, and the buttons to include the eyebrow buttons.

#### Test Configuration
* Firmware version:
* Hardware:
* Toolchain:
* SDK: