### PR TITLE
Update 2A2A1-LEFT_LIP_MODULE.ino

### DIFF
--- a/embedded/OH2_Lower_Instrument_Panel/2A2A1-LEFT_LIP_MODULE/2A2A1-LEFT_LIP_MODULE.ino
+++ b/embedded/OH2_Lower_Instrument_Panel/2A2A1-LEFT_LIP_MODULE/2A2A1-LEFT_LIP_MODULE.ino
@@ -61,7 +61,7 @@
  * 16  | VR MAN
  * 8   | VR Auto
  * 10  | VR LDDI - switch in sim is 3 position
- * 9   | VR IFEI Brightness
+ * A9   | VR IFEI Brightness
  * 
  * @todo When Video Record panel's two remaining 3 positon switches are incorporated into OpenHornet, the sketch should be updated to include them.  Currently VR LDDI not programmed.
  * 
@@ -113,7 +113,7 @@
 #define VR_MAN 16    ///< VR MAN
 #define VR_AUTO 8    ///< VR Auto
 #define VR_LDDI 10   ///< VR LDDI - Switch in SIM is 3 position
-#define VR_A_IFEI 9  ///< VR IFEI Brightness
+#define VR_A_IFEI A9  ///< VR IFEI Brightness
 
 // Connect switches to DCS-BIOS
 DcsBios::Potentiometer ifei("IFEI", VR_A_IFEI);


### PR DESCRIPTION
## Description

A Hornet's Nest reported a bug with the IFEI Brightness knob, with fix on his EP:26 IFEI video.  This commit incorporates the fix to redefining the pin to A9 to fix the analog read.

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.

Closes #

### Dependencies
* List any dependencies that are required for this change, including a full list of libraries required, especially if it is a new or otherwise unused library in the OpenHornet software.

### Type of change
- [ ] New software module (new software module for slave)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update outside of the automatically-generated Doxygen documentation.

### Checklist:
- [x] My code follows the [style guidelines](https://jrsteensen.github.io/OpenHornet-Software/d4/d46/md__2github_2workspace_2_s_t_y_l_e_g_u_i_d_e.html) of this project
- [ ] [I have complied with the software manual](https://jrsteensen.github.io/OpenHornet-Software/d7/d78/md__software_manual.html) for this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code fully with Doxygen compatible comments, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to non-Doxygen generated documentation
- [ ] I have ran Doxygen locally, and it builds the docs successfully
- [ ] My changes generate no errors on compile in Arduino IDE
- [ ] My changes generate no new warnings on compile in Arduino IDE
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] (For sketches only) This sketch complies with OH-INTERCONNECT v**<insert version number here>**
- [ ] If this sketch requires additional libraries, [I have added it as a sub-module per the Arduino Libraries section of the Software Manual.](https://jrsteensen.github.io/OpenHornet-Software/d7/d78/md__software_manual.html)

### How Has This Been Tested?

- [ ] I have tested the sketch in-circuit in DCS with DCS-BIOS and outputs (displays, LEDs, etc.) function as expected. 
- [ ] I have tested the sketch in-circuit in DCS with DCS-BIOS and HID inputs (switches, pots, etc.) function as expected, with switches moving the correct direction.
- [ ] I have tested the sketch in-circuit in DCS with DCS-BIOS and any logic in the sketch has been tested and functions as expected.
- [ ] This code has not yet been tested in-circuit.
- [ ] This code has not yet been tested in DCS-BIOS.

#### Description of Testing
Watched A Hornet's Nest EP:26 video.

#### Test Configuration
* Firmware version:
* Hardware:
* Toolchain:
* SDK: