### PR TITLE
Fix cumulative brightness issue when cycling through MANUAL mode

### DIFF
--- a/embedded/OH2_Lower_Instrument_Panel/2A13-BACKLIGHT_CONTROLLER/helpers/Board.h
+++ b/embedded/OH2_Lower_Instrument_Panel/2A13-BACKLIGHT_CONTROLLER/helpers/Board.h
@@ -147,11 +147,11 @@ public:
             if (currentMode == MODE_NORMAL) {
                 // Reset brightness to a known good state for DCS-BIOS
                 brightness = 128;  // Reset to 50% brightness
-                fillBlack();
+                setAllLightsOff();
                 LedUpdateState::getInstance()->setUpdateFlag(true);   // Activate "update is needed" flag
             }
             if (currentMode == MODE_RAINBOW) {
-                fillBlack();  // Clear any previous state
+                setAllLightsOff();  // Clear any previous state
                 LedUpdateState::getInstance()->setUpdateFlag(true);   // Activate "update is needed" flag
             }
 
@@ -210,12 +210,12 @@ public:
     }
 
     /**
-     * @brief Fills all channels with black
+     * @brief Turns off all lights in all channels and resets brightness state
      * @see This method is called by handleModeChange() in Board.h
      */
-    void fillBlack() {                                                // Fill all channels with black (works in any mode)
+    void setAllLightsOff() {                                         // Turn off all lights and reset brightness state
         for (int i = 0; i < channelCount; i++) {
-            fill_solid(channels[i]->getLeds(), channels[i]->getLedCount(), NVIS_BLACK);
+            channels[i]->setAllLightsOff();
         }
         LedUpdateState::getInstance()->setUpdateFlag(true);
     }

--- a/embedded/OH2_Lower_Instrument_Panel/2A13-BACKLIGHT_CONTROLLER/helpers/Board.h
+++ b/embedded/OH2_Lower_Instrument_Panel/2A13-BACKLIGHT_CONTROLLER/helpers/Board.h
@@ -67,11 +67,14 @@ private:
     int thisHue;                                                      // Current hue value for rainbow effect
     int deltaHue;                                                     // Hue change between LEDs for rainbow effect
     int currentMode;                                                  // Current operating mode
-    int brightness;                                                   // Current brightness level (0-255)
+    int brightness;                                                   // Current brightness level (0-255), for manual mode
+    int dcs_brightness_console;                                        // Current brightness level (0-255), for DCS-BIOS controlled mode
+    int dcs_brightness_instrument;                                     // Current brightness level (0-255), for DCS-BIOS controlled mode
+    int dcs_brightness_flood;                                          // Current brightness level (0-255), for DCS-BIOS controlled mode
 
-    int encSwPin;                                                  // Encoder switch pin
-    RotaryEncoder* encoder;                                            // Pointer to encoder instance
-    int rotary_pos;                                                    // Current rotary encoder position
+    int encSwPin;                                                     // Encoder switch pin
+    RotaryEncoder* encoder;                                           // Pointer to encoder instance
+    int rotary_pos;                                                   // Current rotary encoder position
 
     // Static instance pointer
     static Board* instance;
@@ -146,9 +149,12 @@ public:
             }
             if (currentMode == MODE_NORMAL) {
                 // Reset brightness to a known good state for DCS-BIOS
-                brightness = 128;  // Reset to 50% brightness
+                //brightness = 128;  // Reset to 50% brightness
                 setAllLightsOff();
                 LedUpdateState::getInstance()->setUpdateFlag(true);   // Activate "update is needed" flag
+                sendDcsBiosMessage("CONSOLES_DIMMER", String(dcs_brightness_console).c_str());           // Send DCS-BIOS message to reset console dimmer
+                sendDcsBiosMessage("INST_PNL_DIMMER", String(dcs_brightness_instrument).c_str());              // Send DCS-BIOS message to reset instrument lighting
+                //sendDcsBiosMessage("FLOOD_DIMMER", dcs_brightness_flood);
             }
             if (currentMode == MODE_RAINBOW) {
                 setAllLightsOff();  // Clear any previous state
@@ -239,11 +245,13 @@ public:
      * @see This method is conditionally called by onInstrIntLtChange() in Board.h
      */
     void updateInstrumentLights(uint16_t newValue) {
-        if (currentMode != MODE_NORMAL) return;  // Only update in normal mode
+        dcs_brightness_instrument = newValue;                         // In any mode, store the DCS-BIOS brightness value
+        if (currentMode != MODE_NORMAL) return;                       // Only in normal mode, update the channels
         for (int i = 0; i < channelCount; i++) {
             channels[i]->updateBacklights(newValue);
         }
         LedUpdateState::getInstance()->setUpdateFlag(true);
+        
     }
 
     /**
@@ -252,11 +260,13 @@ public:
      * @see This method is called by onConsolesDimmerChange() in Board.h
      */
     void updateConsoleLights(uint16_t newValue) {
-        if (currentMode != MODE_NORMAL) return;  // Only update in normal mode
+        dcs_brightness_console = newValue;                            // In any mode, store the DCS-BIOS brightness value
+        if (currentMode != MODE_NORMAL) return;                       // Only in normal mode, update the channels
         for (int i = 0; i < channelCount; i++) {
             channels[i]->updateConsoleLights(newValue);
         }
         LedUpdateState::getInstance()->setUpdateFlag(true);
+        
     }
 
 

--- a/embedded/OH2_Lower_Instrument_Panel/2A13-BACKLIGHT_CONTROLLER/helpers/Channel.h
+++ b/embedded/OH2_Lower_Instrument_Panel/2A13-BACKLIGHT_CONTROLLER/helpers/Channel.h
@@ -185,6 +185,18 @@ public:
         }
     }
 
+    /**
+     * @brief Turns off all lights in all panels of this channel and resets brightness state
+     * @see This method is called by Board::fillBlack() to properly reset panel state
+     */
+    void setAllLightsOff() {
+        Panel* current = firstPanel;
+        while (current != nullptr) {
+            current->setAllLightsOff();
+            current = current->nextPanel;
+        }
+    }
+
 };
 
 #endif 

--- a/embedded/OH2_Lower_Instrument_Panel/2A13-BACKLIGHT_CONTROLLER/helpers/Panel.h
+++ b/embedded/OH2_Lower_Instrument_Panel/2A13-BACKLIGHT_CONTROLLER/helpers/Panel.h
@@ -188,6 +188,29 @@ protected:
         }
         LedUpdateState::getInstance()->setUpdateFlag(true);           // Inform that LEDs need to be updated
     }
+
+    /**
+     * @brief Turns off all lights in this panel, irrespective of their role, and resets brightness state
+     * @see This method is called by Board::fillBlack() to properly reset panel state
+     */
+    void setAllLightsOff() {                                          // Turn off all lights and reset brightness state
+        if (!getLedStrip() || !getLedTable()) return;                 // Safety checks
+        
+        CRGB* ledArray = getLedStrip();
+        int startIndex = getStartIndex();
+        int panelLedCount = getLedCount();
+        
+        for (int i = 0; i < panelLedCount; i++) {
+            ledArray[startIndex + i] = NVIS_BLACK;
+        }
+        
+        // Reset all brightness variables to 0
+        current_backl_brightness = 0;
+        current_console_brightness = 0;
+        current_flood_brightness = 0;
+        
+        LedUpdateState::getInstance()->setUpdateFlag(true);           // Inform that LEDs need to be updated
+    }
 };
 
 #endif 

--- a/embedded/OH2_Lower_Instrument_Panel/2A13-BACKLIGHT_CONTROLLER/panels/2A2A1A1_Jett_Station_Panel.h
+++ b/embedded/OH2_Lower_Instrument_Panel/2A13-BACKLIGHT_CONTROLLER/panels/2A2A1A1_Jett_Station_Panel.h
@@ -47,9 +47,9 @@ const Led jettStationLedTable[JETT_STATION_LED_COUNT] PROGMEM = {
     // LO (Left Outer) Station LEDs
     {16, LED_JETT_LO_1}, {17, LED_JETT_LO_1}, {18, LED_JETT_LO_2}, {19, LED_JETT_LO_2},
     // Nose Station LED
-    {20, LED_JETT_NOSE},
+    {20, LED_JETT_NOSE}, {31, LED_JETT_NOSE},
     // Left/Right Station LEDs
-    {21, LED_JETT_LEFT}, {22, LED_JETT_LEFT}, {23, LED_JETT_RIGHT}, {24, LED_JETT_RIGHT},
+    {23, LED_JETT_LEFT}, {24, LED_JETT_LEFT}, {21, LED_JETT_RIGHT}, {22, LED_JETT_RIGHT},
     // Half/Full Station LEDs
     {25, LED_JETT_HALF}, {26, LED_JETT_HALF}, {27, LED_JETT_FULL}, {28, LED_JETT_FULL},
     // Flaps Station LEDs


### PR DESCRIPTION


## Description

- Added setAllLightsOff() method to Panel.h that properly resets brightness state
- Added setAllLightsOff() method to Channel.h to iterate through all panels
- Renamed fillBlack() to setAllLightsOff() in Board.h for consistency
- Fixed issue where Panel brightness variables weren't reset when switching modes

Closes #<issue number>

### Dependencies
No changed dependencies

### Type of change
- [ ] New software module (new software module for slave)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update outside of the automatically-generated Doxygen documentation.

### Checklist:
- [X] My code follows the [style guidelines](https://jrsteensen.github.io/OpenHornet-Software/d4/d46/md__2github_2workspace_2_s_t_y_l_e_g_u_i_d_e.html) of this project
- [X] [I have complied with the software manual](https://jrsteensen.github.io/OpenHornet-Software/d7/d78/md__software_manual.html) for this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code fully with Doxygen compatible comments, particularly in hard-to-understand areas
- [X] I have made corresponding changes to non-Doxygen generated documentation
- [ ] I have ran Doxygen locally, and it builds the docs successfully
- [X] My changes generate no errors on compile in Arduino IDE
- [X] My changes generate no new warnings on compile in Arduino IDE
- [ ] Any dependent changes have been merged and published in downstream modules
- [X] (For sketches only) This sketch complies with OH-INTERCONNECT v**<insert version number here>**
- [ ] If this sketch requires additional libraries, [I have added it as a sub-module per the Arduino Libraries section of the Software Manual.](https://jrsteensen.github.io/OpenHornet-Software/d7/d78/md__software_manual.html)

### How Has This Been Tested?

- [X] I have tested the sketch in-circuit in DCS with DCS-BIOS and outputs (displays, LEDs, etc.) function as expected. 
- [ ] I have tested the sketch in-circuit in DCS with DCS-BIOS and HID inputs (switches, pots, etc.) function as expected, with switches moving the correct direction.
- [X] I have tested the sketch in-circuit in DCS with DCS-BIOS and any logic in the sketch has been tested and functions as expected.
- [ ] This code has not yet been tested in-circuit.
- [ ] This code has not yet been tested in DCS-BIOS.

#### Description of Testing
full test in pit

#### Test Configuration
* Firmware version:
* Hardware:
* Toolchain:
* SDK: