### PR TITLE
Move JETT placard to LIP 1 Channel. Add LED count constants. Improve …

### DIFF
--- a/embedded/OH2_Lower_Instrument_Panel/2A13-BACKLIGHT_CONTROLLER/2A13-BACKLIGHT_CONTROLLER.ino
+++ b/embedded/OH2_Lower_Instrument_Panel/2A13-BACKLIGHT_CONTROLLER/2A13-BACKLIGHT_CONTROLLER.ino
@@ -155,7 +155,8 @@
 #include "panels/2A2A1A8_STANDBY_INSTRUMENT.h"
 #include "panels/4A2A1_LDG_GEAR_PANEL.h"
 #include "panels/4A3A1_SELECT_JETT_PANEL.h"
-#include "panels/4A1_LC_ALL_PANELS.h"
+#include "panels/4A1_LC1_ALL_PANELS.h"
+#include "panels/4A1_LC2_ALL_PANELS.h"
 #include "panels/4A1_LC_Flood.h"
 #include "panels/5A2A7_LDG_CHECKLIST.h"
 #include "panels/5A2A4_RADAR_ALT.h"
@@ -186,8 +187,8 @@ CRGB LIP_1_leds[100];    // 100 LEDs
 CRGB LIP_2_leds[120];    // 120 LEDs
 CRGB UIP_1_leds[210];    // 210 LEDs
 CRGB UIP_2_leds[210];    // 210 LEDs
-CRGB LC_1_leds[304];     // 304 LEDs
-CRGB LC_2_leds[150];     // 150 LEDs
+CRGB LC_1_leds[250];     // 250 LEDs 
+CRGB LC_2_leds[215];     // 215 LEDs
 CRGB RC_1_leds[170];     // 170 LEDs
 CRGB RC_2_leds[266];     // 266 LEDs
 CRGB AUX_1_leds[100];    // 100 LEDs
@@ -198,8 +199,8 @@ Channel LIP_1(13, "Channel 1", LIP_1_leds, 100);
 Channel LIP_2(12, "Channel 2", LIP_2_leds, 120);
 Channel UIP_1(11, "Channel 3", UIP_1_leds, 210);
 Channel UIP_2(10, "Channel 4", UIP_2_leds, 210);                                   
-Channel LC_1(9, "Channel 5", LC_1_leds, 304);                                      
-Channel LC_2(8, "Channel 6", LC_2_leds, 150);
+Channel LC_1(9, "Channel 5", LC_1_leds, 250);                                      
+Channel LC_2(8, "Channel 6", LC_2_leds, 215);
 Channel RC_1(7, "Channel 7", RC_1_leds, 170);               
 Channel RC_2(6, "Channel 8", RC_2_leds, 266);               
 Channel AUX_1(5, "Channel 9", AUX_1_leds, 100);                       //Spare channel
@@ -259,7 +260,9 @@ void setup() {
 
     LC_1.addPanel<LdgGearPanel>();
     LC_1.addPanel<SelectJettPanel>();
-    LC_1.addPanel<LcAllPanels>();
+    LC_1.addPanel<Lc1AllPanels>();
+    
+    LC_2.addPanel<Lc2AllPanels>();
 
     RC_1.addPanel<LdgChecklistPanel>();
     RC_1.addPanel<RadarAltPanel>();

--- a/embedded/OH2_Lower_Instrument_Panel/2A13-BACKLIGHT_CONTROLLER/2A13-BACKLIGHT_CONTROLLER.ino
+++ b/embedded/OH2_Lower_Instrument_Panel/2A13-BACKLIGHT_CONTROLLER/2A13-BACKLIGHT_CONTROLLER.ino
@@ -32,8 +32,8 @@
 /**
  * @file    2A13-BACKLIGHT_CONTROLLER.ino
  * @author  Ulukaii, Arribe, Higgins
- * @date    May 22, 2025
- * @version V 0.3.2 ( partially tested)
+ * @date    August 03, 2025
+ * @version V 0.4.5 (tested)
  * @warning This sketch is based on OH-Interconnect. Adapt it to your actual wiring and 
  *          panel versions.
  * @brief   Controls backlights & most annunciators. 
@@ -62,27 +62,58 @@
  *          | 2   | J12 & J13 Cooling fan headers |                  |
  *   
  *          **How to use**
- *          If you are building according to spec, you only need to work with this file:
- *          - In the setup() function, add only those panels that you are using.
- *          - When adding, adjust the panel order according to your physical connections.
- *          - Make sure that the pins defined below match your physical wiring.
- *          - There is no need to adapt any indexes or LED counts, anyhwere.
- *          If you want to change the colors:
- *          - Open the Colors.h file and change the color definitions.
- *          - Adapt individually as needed for your build and LEDs in use.
- *          - Colors according MIL-STD-3099 are documented in the Colors.h file.
- *          - Note: LEDs dimming uses FastLED's nscale8_video() function. It provides a
- *            more color-preserving dimming effect than pure RGB value recalculation.
- *          If you have an non-standard wiring / pinout of your backlight controller:
- *          - Adapt the pinout in the "Define pinouts and channels" section in this file.
- *          If you are using custom panels: 
- *          - Adapt or create a new panel class in the "panels" folder; 
- *            you may use the 1A2A1_MASTER_ARM.h as template. 
- *          - Make sure to use the same concepts (Inherit from panel class, singleton, 
- *            PROGMEM etc.) as the other panels. Creating of a LED_TEXT table is optional.
- *          - Add the panel to a channel in the setup() function.
- *          - Adapt the max LED count of the affected channel as needed in the 
- *            "Define pinouts and channels" section.
+ *          (1) If you are building according to spec:
+ *              ...you only need to work with this file (the main .ino). Generally, the 
+ *              code in this files works as follows: at power up, three kinds of objects 
+ *              are created: one Board() object (think of it as the top-level object) that 
+ *              represents the BLM board itself. Ten Channel() objects, each of which 
+ *              represent on of the ten BL channels. And many Panel() objects, each of 
+ *              which represents a specific panel in the pit.
+ *              The board object handles the mode change logic. 
+ *              The channel objects handle the LED strips and FastLED commands.
+ *              The panel objects contain their LED roles and handle DCS-Bios commands.
+ *              In the setup() function, add only those panels that you are using. When 
+ *              adding, adjust the panel order according to your physical connections. 
+ *              Comment out the panels that you do not have connected. You do not need to 
+ *              adapt any LED indices or LED counts, or other files, anywhere. Also make 
+ *              sure that the pins defined below match your physical wiring.
+ *          (2) If you add panels in a non-standard order: 
+ *              Adapt the panel order in the setup() function as described in (1). If you
+ *              intend to add more panels to a channel than the default, make sure that you
+ *              increase the LED count of the affected channel (e.g. LIP_1_LED_COUNT) in 
+ *              the "Define pinouts and channels" section appropriately.
+ *          (3) If you want to change the colors: 
+ *              Open the Colors.h file and change the color definitions. Observe that in
+ *              this file, the colours according to MIL-STD-3099 are documented. However,
+ *              these may not fit exactly to the visual output that your LEDs provide. 
+ *              Therefore, adapt colors as needed for your build and LEDs in use.
+ *              Note: LEDs dimming uses FastLED's nscale8_video() function. It provides a
+ *              more color-preserving dimming effect than pure RGB value recalculation.
+ *          (4) If you have an non-standard wiring / pinout of your backlight controller:
+ *              Adapt the pinout in the "Define pinouts and channels" section in this file.
+ *          (5) If you are using custom panels: 
+ *              Adapt or create a new panel class in the "panels" folder. You may use the 
+ *              1A2A1_MASTER_ARM.h as template. Make sure to follow its structure closely.
+ * 
+ *          **Starting up* for the first time**
+ *          The BLM will start in mode 1 (DCS-BIOS) mode by default. This means you should
+ *          see only dark panels. By pressing the rotary encoder, you can switch to mode 2
+ *          (manual mode) and see manually dimmable backlights in green. Pressing again, 
+ *          you should see the rainbow pattern. Pressing again, you get back to mode 1. 
+ * 
+ *          **Troubleshooting**
+ *          (!) If the panels stay dark:
+ *              First confirm the correct wiring of the rotary  encoder. Second, observe
+ *              if the onboard LED is blinking fast. If so, this means that the power-on
+ *              self-test has detected an exceedance of  panels added to a channel. In 
+ *              this case, you need to increase the LED count of the affected channel in 
+ *              the "Define pinouts and channels" section.
+ *              If the onboard LED is not blinking, the code failed to initialize and 
+ *              start up properly. Revert the last changes.
+ *          (!) If the BLM does not react after a while of operation: 
+ *              I observed that a faulty LED on a panel can cause the BLM to stop working 
+ *              after a few mins of operation. The faulty LED is usually the first LED on 
+ *              a channel that stays dark. Replacing the faulty LED should fix the issue.
  * 
  *          **Technical Background**
  *          This sketch addresses the following functional OH requirements:
@@ -93,9 +124,9 @@
  *          5. Different users may build a different subset of panels and connect them 
  *             in varying orders as their build progresses; the code must be modular
  *             enough to allow this. 
- *          6. As the users' build progresses:
- *             - She/he shall not need to recalculate LED indices/counts
- *             - She/he shall not need to reprogram this BL controller (if build to spec)
+ *          6. As the users' build progresses, and more panels are added, the user shall 
+ *             not need to recalculate LED indices/counts. She/he shall not need to 
+ *             reprogram this BL controller (if build to spec)
  *          7. Code execution must be fast to avoid LED flickering (output side) or loss 
  *              of updates coming from DCS-BIOS (input side).
  *          8. Extensible for a future use of the PREFLT function (feasibility TBD)
@@ -170,7 +201,7 @@
 
 
 /********************************************************************************************************************
- * @brief   Define pinouts and channels 
+ * @brief   Define pinouts, LED counts and LED channels 
  * @remark  Check that the pinout corresponds to (YOUR!) wiring.
  * @details Syntax: Channel <Name as on Interconnect>(hardware pin, "Channel name as on PCB", expected max. led count);
  *          When adapting below code, observe memory constraints. Each LED uses 3 bytes of SRAM. 8KB are available.
@@ -181,31 +212,44 @@ const int encSw =    24;
 const int encA  =    22;              
 const int encB  =    23;  
 
+// LED counts for each channel
+const int LIP_1_LED_COUNT = 100;
+const int LIP_2_LED_COUNT = 120;
+const int UIP_1_LED_COUNT = 210;
+const int UIP_2_LED_COUNT = 210;
+const int LC_1_LED_COUNT = 304;
+const int LC_2_LED_COUNT = 150;
+const int RC_1_LED_COUNT = 170;
+const int RC_2_LED_COUNT = 266;
+const int AUX_1_LED_COUNT = 100;
+const int AUX_2_LED_COUNT = 100;
+
 // Static LED arrays for each channel
-CRGB LIP_1_leds[100];    // 100 LEDs
-CRGB LIP_2_leds[120];    // 120 LEDs
-CRGB UIP_1_leds[210];    // 210 LEDs
-CRGB UIP_2_leds[210];    // 210 LEDs
-CRGB LC_1_leds[304];     // 304 LEDs
-CRGB LC_2_leds[150];     // 150 LEDs
-CRGB RC_1_leds[170];     // 170 LEDs
-CRGB RC_2_leds[266];     // 266 LEDs
-CRGB AUX_1_leds[100];    // 100 LEDs
-CRGB AUX_2_leds[100];    // 100 LEDs
+CRGB LIP_1_leds[LIP_1_LED_COUNT];    // 100 LEDs
+CRGB LIP_2_leds[LIP_2_LED_COUNT];    // 120 LEDs
+CRGB UIP_1_leds[UIP_1_LED_COUNT];    // 210 LEDs
+CRGB UIP_2_leds[UIP_2_LED_COUNT];    // 210 LEDs
+CRGB LC_1_leds[LC_1_LED_COUNT];     // 304 LEDs
+CRGB LC_2_leds[LC_2_LED_COUNT];     // 150 LEDs
+CRGB RC_1_leds[RC_1_LED_COUNT];     // 170 LEDs
+CRGB RC_2_leds[RC_2_LED_COUNT];     // 266 LEDs
+CRGB AUX_1_leds[AUX_1_LED_COUNT];    // 100 LEDs
+CRGB AUX_2_leds[AUX_2_LED_COUNT];    // 100 LEDs
 
-// Define channel objects (and create them)
-Channel LIP_1(13, "Channel 1", LIP_1_leds, 100);
-Channel LIP_2(12, "Channel 2", LIP_2_leds, 120);
-Channel UIP_1(11, "Channel 3", UIP_1_leds, 210);
-Channel UIP_2(10, "Channel 4", UIP_2_leds, 210);                                   
-Channel LC_1(9, "Channel 5", LC_1_leds, 304);                                      
-Channel LC_2(8, "Channel 6", LC_2_leds, 150);
-Channel RC_1(7, "Channel 7", RC_1_leds, 170);               
-Channel RC_2(6, "Channel 8", RC_2_leds, 266);               
-Channel AUX_1(5, "Channel 9", AUX_1_leds, 100);                       //Spare channel
-Channel AUX_2(4, "Channel 10", AUX_2_leds, 100);                      //Spare channel
+// Create objects of "channel" class (with the right LED count)
+Channel LIP_1(13, "Channel 1", LIP_1_leds, LIP_1_LED_COUNT);
+Channel LIP_2(12, "Channel 2", LIP_2_leds, LIP_2_LED_COUNT);
+Channel UIP_1(11, "Channel 3", UIP_1_leds, UIP_1_LED_COUNT);
+Channel UIP_2(10, "Channel 4", UIP_2_leds, UIP_2_LED_COUNT);                                   
+Channel LC_1(9, "Channel 5", LC_1_leds, LC_1_LED_COUNT);                                      
+Channel LC_2(8, "Channel 6", LC_2_leds, LC_2_LED_COUNT);
+Channel RC_1(7, "Channel 7", RC_1_leds, RC_1_LED_COUNT);               
+Channel RC_2(6, "Channel 8", RC_2_leds, RC_2_LED_COUNT);               
+Channel AUX_1(5, "Channel 9", AUX_1_leds, AUX_1_LED_COUNT);           //Spare channel
+Channel AUX_2(4, "Channel 10", AUX_2_leds, AUX_2_LED_COUNT);          //Spare channel
 
-Board* board;                                                         // Pointer to singleton board instance
+// Create pointer to singleton board instance
+Board* board;                                                         
 
 
 /********************************************************************************************************************
@@ -218,10 +262,10 @@ void setup() {
     board->initializeBoard(encSw, encA, encB);                        // Initialize board with encoder pins
     
     // Initialize all channels
-    LIP_1.initialize();                                               // Initialize channels with FastLED
-    LIP_2.initialize();
-    UIP_1.initialize();
-    UIP_2.initialize();
+    LIP_1.initialize();                                               // Calling .initialize() on a channel object will
+    LIP_2.initialize();                                               // trigger FastLED.addLeds() with pin and led count
+    UIP_1.initialize();                                               
+    UIP_2.initialize();                                               
     LC_1.initialize();
     LC_2.initialize();
     RC_1.initialize();
@@ -229,9 +273,8 @@ void setup() {
     AUX_1.initialize();
     AUX_2.initialize();
 
-    // Register all channels with the board
-    board->registerChannel(&LIP_1);                                   // Register channels with the board
-    board->registerChannel(&LIP_2);
+    board->registerChannel(&LIP_1);                                   // Register channels with the board, so they are
+    board->registerChannel(&LIP_2);                                   // accessible by the board object
     board->registerChannel(&UIP_1);
     board->registerChannel(&UIP_2);
     board->registerChannel(&LC_1);
@@ -250,11 +293,12 @@ void setup() {
     LIP_1.addPanel<IfeiPanel>();
     LIP_1.addPanel<VideoRecordPanel>();
     LIP_1.addPanel<JettStationPanel>();
+    LIP_1.addPanel<JettPlacardPanel>();
 
     LIP_2.addPanel<EcmPanel>();
     LIP_2.addPanel<RwrControlPanel>();
     LIP_2.addPanel<StandbyInstrumentPanel>();
-    //LIP_2.addPanel<JettPlacardPanel>();
+    
 
 
     LC_1.addPanel<LdgGearPanel>();

--- a/embedded/OH2_Lower_Instrument_Panel/2A13-BACKLIGHT_CONTROLLER/2A13-BACKLIGHT_CONTROLLER.ino
+++ b/embedded/OH2_Lower_Instrument_Panel/2A13-BACKLIGHT_CONTROLLER/2A13-BACKLIGHT_CONTROLLER.ino
@@ -288,6 +288,7 @@ void setup() {
     UIP_1.addPanel<MasterArmPanel>();                                 // Instantiate the panels;
     UIP_1.addPanel<EwiPanel>();                                       // Adapt order according to your physical wiring; 
     //UIP_1.addPanel<HudPanel>();                                     // Do not exceed the channel's LED count defined above.
+    //UIP_1.addPanel<HudPanelRev3>();
     UIP_1.addPanel<REwiPanel>();
     UIP_1.addPanel<SpnRcvyPanel>();
 

--- a/embedded/OH2_Lower_Instrument_Panel/2A13-BACKLIGHT_CONTROLLER/panels/4A1_LC1_ALL_PANELS.h
+++ b/embedded/OH2_Lower_Instrument_Panel/2A13-BACKLIGHT_CONTROLLER/panels/4A1_LC1_ALL_PANELS.h
@@ -4,23 +4,23 @@
  *      | |  | |_ __   ___ _ __ | |__| | ___  _ __ _ __   ___| |_
  *      | |  | | '_ \ / _ \ '_ \|  __  |/ _ \| '__| '_ \ / _ \ __|
  *      | |__| | |_) |  __/ | | | |  | | (_) | |  | | | |  __/ |_
- *       \____/| .__/ \___|_| |_|_|  |_|\___/|_|  |_| |_|\___|\__|
+ *       \____/| .__/ \___|_| |_|_|  |_|\___|_|  |_| |_|\___|\__|
  *             | |
  *             |_|
  *   ----------------------------------------------------------------------------------
  *  
- * @file      4A1_LC_ALL_PANELS.h
+ * @file      4A1_LC1_ALL_PANELS.h
  * @author    Ulukaii
  * @date      24.05.2025
  * @version   t 0.3.2
  * @copyright Copyright 2016-2025 OpenHornet. See 2A13-BACKLIGHT_CONTROLLER.ino for details.
- * @brief     Implements backlighting for all Left Console panels.
+ * @brief     Implements backlighting for Left Console 1 panels.
  * @warning   This is a shorthanded version; a future implementation foresees individual files for each panel on the LC.
  *********************************************************************************************************************/
 
 
-#ifndef __LC_ALL_PANELS_H
-#define __LC_ALL_PANELS_H
+#ifndef __LC1_ALL_PANELS_H
+#define __LC1_ALL_PANELS_H
 
 #include "DcsBios.h"
 #include "../helpers/Panel.h"
@@ -30,8 +30,8 @@
  * @details "Role" in this context refers to the LED role enum in the Panel.h file (enum used for memory efficiency).
  * @remark  This table is stored in PROGMEM for memory efficiency.
  ********************************************************************************************************************/
-const int LC_ALL_PANELS_LED_COUNT = 200;  // Total number of LEDs in the panel
-const Led lcAllPanelsLedTable[LC_ALL_PANELS_LED_COUNT] PROGMEM = {
+const int LC1_ALL_PANELS_LED_COUNT = 130;  // Total number of LEDs in the panel
+const Led lc1AllPanelsLedTable[LC1_ALL_PANELS_LED_COUNT] PROGMEM = {
     {0, LED_CONSOLE_BL}, {1, LED_CONSOLE_BL}, {2, LED_CONSOLE_BL}, {3, LED_CONSOLE_BL}, {4, LED_CONSOLE_BL}, 
     {5, LED_CONSOLE_BL}, {6, LED_CONSOLE_BL}, {7, LED_CONSOLE_BL}, {8, LED_CONSOLE_BL}, {9, LED_CONSOLE_BL},
     {10, LED_CONSOLE_BL}, {11, LED_CONSOLE_BL}, {12, LED_CONSOLE_BL}, {13, LED_CONSOLE_BL}, {14, LED_CONSOLE_BL}, 
@@ -57,44 +57,30 @@ const Led lcAllPanelsLedTable[LC_ALL_PANELS_LED_COUNT] PROGMEM = {
     {110, LED_CONSOLE_BL}, {111, LED_CONSOLE_BL}, {112, LED_CONSOLE_BL}, {113, LED_CONSOLE_BL}, {114, LED_CONSOLE_BL}, 
     {115, LED_CONSOLE_BL}, {116, LED_CONSOLE_BL}, {117, LED_CONSOLE_BL}, {118, LED_CONSOLE_BL}, {119, LED_CONSOLE_BL},
     {120, LED_CONSOLE_BL}, {121, LED_CONSOLE_BL}, {122, LED_CONSOLE_BL}, {123, LED_CONSOLE_BL}, {124, LED_CONSOLE_BL}, 
-    {125, LED_CONSOLE_BL}, {126, LED_CONSOLE_BL}, {127, LED_CONSOLE_BL}, {128, LED_CONSOLE_BL}, {129, LED_CONSOLE_BL},
-    {130, LED_CONSOLE_BL}, {131, LED_CONSOLE_BL}, {132, LED_CONSOLE_BL}, {133, LED_CONSOLE_BL}, {134, LED_CONSOLE_BL}, 
-    {135, LED_CONSOLE_BL}, {136, LED_CONSOLE_BL}, {137, LED_CONSOLE_BL}, {138, LED_CONSOLE_BL}, {139, LED_CONSOLE_BL},
-    {140, LED_CONSOLE_BL}, {141, LED_CONSOLE_BL}, {142, LED_CONSOLE_BL}, {143, LED_CONSOLE_BL}, {144, LED_CONSOLE_BL}, 
-    {145, LED_CONSOLE_BL}, {146, LED_CONSOLE_BL}, {147, LED_CONSOLE_BL}, {148, LED_CONSOLE_BL}, {149, LED_CONSOLE_BL},
-    {150, LED_CONSOLE_BL}, {151, LED_CONSOLE_BL}, {152, LED_CONSOLE_BL}, {153, LED_CONSOLE_BL}, {154, LED_CONSOLE_BL}, 
-    {155, LED_CONSOLE_BL}, {156, LED_CONSOLE_BL}, {157, LED_CONSOLE_BL}, {158, LED_CONSOLE_BL}, {159, LED_CONSOLE_BL},
-    {160, LED_CONSOLE_BL}, {161, LED_CONSOLE_BL}, {162, LED_CONSOLE_BL}, {163, LED_CONSOLE_BL}, {164, LED_CONSOLE_BL}, 
-    {165, LED_CONSOLE_BL}, {166, LED_CONSOLE_BL}, {167, LED_CONSOLE_BL}, {168, LED_CONSOLE_BL}, {169, LED_CONSOLE_BL},
-    {170, LED_CONSOLE_BL}, {171, LED_CONSOLE_BL}, {172, LED_CONSOLE_BL}, {173, LED_CONSOLE_BL}, {174, LED_CONSOLE_BL}, 
-    {175, LED_CONSOLE_BL}, {176, LED_CONSOLE_BL}, {177, LED_CONSOLE_BL}, {178, LED_CONSOLE_BL}, {179, LED_CONSOLE_BL},
-    {180, LED_CONSOLE_BL}, {181, LED_CONSOLE_BL}, {182, LED_CONSOLE_BL}, {183, LED_CONSOLE_BL}, {184, LED_CONSOLE_BL}, 
-    {185, LED_CONSOLE_BL}, {186, LED_CONSOLE_BL}, {187, LED_CONSOLE_BL}, {188, LED_CONSOLE_BL}, {189, LED_CONSOLE_BL},
-    {190, LED_CONSOLE_BL}, {191, LED_CONSOLE_BL}, {192, LED_CONSOLE_BL}, {193, LED_CONSOLE_BL}, {194, LED_CONSOLE_BL}, 
-    {195, LED_CONSOLE_BL}, {196, LED_CONSOLE_BL}, {197, LED_CONSOLE_BL}, {198, LED_CONSOLE_BL}, {199, LED_CONSOLE_BL}
+    {125, LED_CONSOLE_BL}, {126, LED_CONSOLE_BL}, {127, LED_CONSOLE_BL}, {128, LED_CONSOLE_BL}, {129, LED_CONSOLE_BL}
 };
 
 /********************************************************************************************************************
- * @brief   Left Console All Panels class
- * @details Backlighting controller for all Left Console panels.
- *          Total LEDs: 200
- *          Backlight LEDs: 200 (all LEDs are backlights)
+ * @brief   Left Console 1 All Panels class
+ * @details Backlighting controller for Left Console 1 panels.
+ *          Total LEDs: 130
+ *          Backlight LEDs: 130 (all LEDs are backlights)
  *          Indicator LEDs: 0 (no indicators in this panel)
  * @remark  This class inherits from the "basic" Panel class in panels/Panel.h
  *          It also enforces a singleton pattern; this is required to use DCS-BIOS callbacks in class methods.
  ********************************************************************************************************************/
-class LcAllPanels : public Panel {
+class Lc1AllPanels : public Panel {
 public:
     /**
-     * @brief Gets the singleton instance of the LcAllPanels class
+     * @brief Gets the singleton instance of the Lc1AllPanels class
      * @param startIndex The starting index for this panel's LEDs on the strip
      * @param ledStrip Pointer to the LED strip array
      * @return Pointer to the singleton instance
      * @see This method is called by the main .ino file's addPanel() method to create the panel instance
      */
-    static LcAllPanels* getInstance(int startIndex = 0, CRGB* ledStrip = nullptr) {
+    static Lc1AllPanels* getInstance(int startIndex = 0, CRGB* ledStrip = nullptr) {
         if (!instance) {
-            instance = new LcAllPanels(startIndex, ledStrip);
+            instance = new Lc1AllPanels(startIndex, ledStrip);
         }
         return instance;
     }
@@ -106,21 +92,21 @@ private:
      * @param ledStrip Pointer to the LED strip array
      * @see This method is called by the public getInstance() if and only if no instance exists yet
      */
-    LcAllPanels(int startIndex, CRGB* ledStrip) {
+    Lc1AllPanels(int startIndex, CRGB* ledStrip) {
         panelStartIndex = startIndex;
         this->ledStrip = ledStrip;
-        ledCount = LC_ALL_PANELS_LED_COUNT;
-        ledTable = lcAllPanelsLedTable;
+        ledCount = LC1_ALL_PANELS_LED_COUNT;
+        ledTable = lc1AllPanelsLedTable;
     }
 
     // Static callback functions for DCS-BIOS
     // NIL
 
     // Instance data
-    static LcAllPanels* instance;
+    static Lc1AllPanels* instance;
 };
 
 // Initialize static instance pointer
-LcAllPanels* LcAllPanels::instance = nullptr;
+Lc1AllPanels* Lc1AllPanels::instance = nullptr;
 
 #endif 

--- a/embedded/OH2_Lower_Instrument_Panel/2A13-BACKLIGHT_CONTROLLER/panels/4A1_LC2_ALL_PANELS.h
+++ b/embedded/OH2_Lower_Instrument_Panel/2A13-BACKLIGHT_CONTROLLER/panels/4A1_LC2_ALL_PANELS.h
@@ -1,0 +1,129 @@
+/**********************************************************************************************************************
+ *        ____                   _    _                       _
+ *       / __ \                 | |  | |                     | |
+ *      | |  | |_ __   ___ _ __ | |__| | ___  _ __ _ __   ___| |_
+ *      | |  | | '_ \ / _ \ '_ \|  __  |/ _ \| '__| '_ \ / _ \ __|
+ *      | |__| | |_) |  __/ | | | |  | | (_) | |  | | | |  __/ |_
+ *       \____/| .__/ \___|_| |_|_|  |_|\___|_|  |_| |_|\___|\__|
+ *             | |
+ *             |_|
+ *   ----------------------------------------------------------------------------------
+ *  
+ * @file      4A1_LC2_ALL_PANELS.h
+ * @author    Ulukaii
+ * @date      24.05.2025
+ * @version   t 0.3.2
+ * @copyright Copyright 2016-2025 OpenHornet. See 2A13-BACKLIGHT_CONTROLLER.ino for details.
+ * @brief     Implements backlighting for Left Console 2 panels.
+ * @warning   This is a shorthanded version; a future implementation foresees individual files for each panel on the LC.
+ *********************************************************************************************************************/
+
+
+#ifndef __LC2_ALL_PANELS_H
+#define __LC2_ALL_PANELS_H
+
+#include "DcsBios.h"
+#include "../helpers/Panel.h"
+
+/********************************************************************************************************************
+ * @brief   This table defines the panel's LEDs.
+ * @details "Role" in this context refers to the LED role enum in the Panel.h file (enum used for memory efficiency).
+ * @remark  This table is stored in PROGMEM for memory efficiency.
+ ********************************************************************************************************************/
+const int LC2_ALL_PANELS_LED_COUNT = 215;  // Total number of LEDs in the panel
+const Led lc2AllPanelsLedTable[LC2_ALL_PANELS_LED_COUNT] PROGMEM = {
+    {0, LED_CONSOLE_BL}, {1, LED_CONSOLE_BL}, {2, LED_CONSOLE_BL}, {3, LED_CONSOLE_BL}, {4, LED_CONSOLE_BL}, 
+    {5, LED_CONSOLE_BL}, {6, LED_CONSOLE_BL}, {7, LED_CONSOLE_BL}, {8, LED_CONSOLE_BL}, {9, LED_CONSOLE_BL},
+    {10, LED_CONSOLE_BL}, {11, LED_CONSOLE_BL}, {12, LED_CONSOLE_BL}, {13, LED_CONSOLE_BL}, {14, LED_CONSOLE_BL}, 
+    {15, LED_CONSOLE_BL}, {16, LED_CONSOLE_BL}, {17, LED_CONSOLE_BL}, {18, LED_CONSOLE_BL}, {19, LED_CONSOLE_BL},
+    {20, LED_CONSOLE_BL}, {21, LED_CONSOLE_BL}, {22, LED_CONSOLE_BL}, {23, LED_CONSOLE_BL}, {24, LED_CONSOLE_BL}, 
+    {25, LED_CONSOLE_BL}, {26, LED_CONSOLE_BL}, {27, LED_CONSOLE_BL}, {28, LED_CONSOLE_BL}, {29, LED_CONSOLE_BL},
+    {30, LED_CONSOLE_BL}, {31, LED_CONSOLE_BL}, {32, LED_CONSOLE_BL}, {33, LED_CONSOLE_BL}, {34, LED_CONSOLE_BL}, 
+    {35, LED_CONSOLE_BL}, {36, LED_CONSOLE_BL}, {37, LED_CONSOLE_BL}, {38, LED_CONSOLE_BL}, {39, LED_CONSOLE_BL},
+    {40, LED_CONSOLE_BL}, {41, LED_CONSOLE_BL}, {42, LED_CONSOLE_BL}, {43, LED_CONSOLE_BL}, {44, LED_CONSOLE_BL}, 
+    {45, LED_CONSOLE_BL}, {46, LED_CONSOLE_BL}, {47, LED_CONSOLE_BL}, {48, LED_CONSOLE_BL}, {49, LED_CONSOLE_BL},
+    {50, LED_CONSOLE_BL}, {51, LED_CONSOLE_BL}, {52, LED_CONSOLE_BL}, {53, LED_CONSOLE_BL}, {54, LED_CONSOLE_BL}, 
+    {55, LED_CONSOLE_BL}, {56, LED_CONSOLE_BL}, {57, LED_CONSOLE_BL}, {58, LED_CONSOLE_BL}, {59, LED_CONSOLE_BL},
+    {60, LED_CONSOLE_BL}, {61, LED_CONSOLE_BL}, {62, LED_CONSOLE_BL}, {63, LED_CONSOLE_BL}, {64, LED_CONSOLE_BL}, 
+    {65, LED_CONSOLE_BL}, {66, LED_CONSOLE_BL}, {67, LED_CONSOLE_BL}, {68, LED_CONSOLE_BL}, {69, LED_CONSOLE_BL},
+    {70, LED_CONSOLE_BL}, {71, LED_CONSOLE_BL}, {72, LED_CONSOLE_BL}, {73, LED_CONSOLE_BL}, {74, LED_CONSOLE_BL}, 
+    {75, LED_CONSOLE_BL}, {76, LED_CONSOLE_BL}, {77, LED_CONSOLE_BL}, {78, LED_CONSOLE_BL}, {79, LED_CONSOLE_BL},
+    {80, LED_CONSOLE_BL}, {81, LED_CONSOLE_BL}, {82, LED_CONSOLE_BL}, {83, LED_CONSOLE_BL}, {84, LED_CONSOLE_BL}, 
+    {85, LED_CONSOLE_BL}, {86, LED_CONSOLE_BL}, {87, LED_CONSOLE_BL}, {88, LED_CONSOLE_BL}, {89, LED_CONSOLE_BL},
+    {90, LED_CONSOLE_BL}, {91, LED_CONSOLE_BL}, {92, LED_CONSOLE_BL}, {93, LED_CONSOLE_BL}, {94, LED_CONSOLE_BL}, 
+    {95, LED_CONSOLE_BL}, {96, LED_CONSOLE_BL}, {97, LED_CONSOLE_BL}, {98, LED_CONSOLE_BL}, {99, LED_CONSOLE_BL},
+    {100, LED_CONSOLE_BL}, {101, LED_CONSOLE_BL}, {102, LED_CONSOLE_BL}, {103, LED_CONSOLE_BL}, {104, LED_CONSOLE_BL}, 
+    {105, LED_CONSOLE_BL}, {106, LED_CONSOLE_BL}, {107, LED_CONSOLE_BL}, {108, LED_CONSOLE_BL}, {109, LED_CONSOLE_BL},
+    {110, LED_CONSOLE_BL}, {111, LED_CONSOLE_BL}, {112, LED_CONSOLE_BL}, {113, LED_CONSOLE_BL}, {114, LED_CONSOLE_BL}, 
+    {115, LED_CONSOLE_BL}, {116, LED_CONSOLE_BL}, {117, LED_CONSOLE_BL}, {118, LED_CONSOLE_BL}, {119, LED_CONSOLE_BL},
+    {120, LED_CONSOLE_BL}, {121, LED_CONSOLE_BL}, {122, LED_CONSOLE_BL}, {123, LED_CONSOLE_BL}, {124, LED_CONSOLE_BL}, 
+    {125, LED_CONSOLE_BL}, {126, LED_CONSOLE_BL}, {127, LED_CONSOLE_BL}, {128, LED_CONSOLE_BL}, {129, LED_CONSOLE_BL},
+    {130, LED_CONSOLE_BL}, {131, LED_CONSOLE_BL}, {132, LED_CONSOLE_BL}, {133, LED_CONSOLE_BL}, {134, LED_CONSOLE_BL}, 
+    {135, LED_CONSOLE_BL}, {136, LED_CONSOLE_BL}, {137, LED_CONSOLE_BL}, {138, LED_CONSOLE_BL}, {139, LED_CONSOLE_BL},
+    {140, LED_CONSOLE_BL}, {141, LED_CONSOLE_BL}, {142, LED_CONSOLE_BL}, {143, LED_CONSOLE_BL}, {144, LED_CONSOLE_BL}, 
+    {145, LED_CONSOLE_BL}, {146, LED_CONSOLE_BL}, {147, LED_CONSOLE_BL}, {148, LED_CONSOLE_BL}, {149, LED_CONSOLE_BL},
+    {150, LED_CONSOLE_BL}, {151, LED_CONSOLE_BL}, {152, LED_CONSOLE_BL}, {153, LED_CONSOLE_BL}, {154, LED_CONSOLE_BL}, 
+    {155, LED_CONSOLE_BL}, {156, LED_CONSOLE_BL}, {157, LED_CONSOLE_BL}, {158, LED_CONSOLE_BL}, {159, LED_CONSOLE_BL},
+    {160, LED_CONSOLE_BL}, {161, LED_CONSOLE_BL}, {162, LED_CONSOLE_BL}, {163, LED_CONSOLE_BL}, {164, LED_CONSOLE_BL}, 
+    {165, LED_CONSOLE_BL}, {166, LED_CONSOLE_BL}, {167, LED_CONSOLE_BL}, {168, LED_CONSOLE_BL}, {169, LED_CONSOLE_BL},
+    {170, LED_CONSOLE_BL}, {171, LED_CONSOLE_BL}, {172, LED_CONSOLE_BL}, {173, LED_CONSOLE_BL}, {174, LED_CONSOLE_BL}, 
+    {175, LED_CONSOLE_BL}, {176, LED_CONSOLE_BL}, {177, LED_CONSOLE_BL}, {178, LED_CONSOLE_BL}, {179, LED_CONSOLE_BL},
+    {180, LED_CONSOLE_BL}, {181, LED_CONSOLE_BL}, {182, LED_CONSOLE_BL}, {183, LED_CONSOLE_BL}, {184, LED_CONSOLE_BL}, 
+    {185, LED_CONSOLE_BL}, {186, LED_CONSOLE_BL}, {187, LED_CONSOLE_BL}, {188, LED_CONSOLE_BL}, {189, LED_CONSOLE_BL},
+    {190, LED_CONSOLE_BL}, {191, LED_CONSOLE_BL}, {192, LED_CONSOLE_BL}, {193, LED_CONSOLE_BL}, {194, LED_CONSOLE_BL}, 
+    {195, LED_CONSOLE_BL}, {196, LED_CONSOLE_BL}, {197, LED_CONSOLE_BL}, {198, LED_CONSOLE_BL}, {199, LED_CONSOLE_BL},
+    {200, LED_CONSOLE_BL}, {201, LED_CONSOLE_BL}, {202, LED_CONSOLE_BL}, {203, LED_CONSOLE_BL}, {204, LED_CONSOLE_BL}, 
+    {205, LED_CONSOLE_BL}, {206, LED_CONSOLE_BL}, {207, LED_CONSOLE_BL}, {208, LED_CONSOLE_BL}, {209, LED_CONSOLE_BL},
+    {210, LED_CONSOLE_BL}, {211, LED_CONSOLE_BL}, {212, LED_CONSOLE_BL}, {213, LED_CONSOLE_BL}, {214, LED_CONSOLE_BL}
+};
+
+/********************************************************************************************************************
+ * @brief   Left Console 2 All Panels class
+ * @details Backlighting controller for Left Console 2 panels.
+ *          Total LEDs: 215
+ *          Backlight LEDs: 215 (all LEDs are backlights)
+ *          Indicator LEDs: 0 (no indicators in this panel)
+ * @remark  This class inherits from the "basic" Panel class in panels/Panel.h
+ *          It also enforces a singleton pattern; this is required to use DCS-BIOS callbacks in class methods.
+ ********************************************************************************************************************/
+class Lc2AllPanels : public Panel {
+public:
+    /**
+     * @brief Gets the singleton instance of the Lc2AllPanels class
+     * @param startIndex The starting index for this panel's LEDs on the strip
+     * @param ledStrip Pointer to the LED strip array
+     * @return Pointer to the singleton instance
+     * @see This method is called by the main .ino file's addPanel() method to create the panel instance
+     */
+    static Lc2AllPanels* getInstance(int startIndex = 0, CRGB* ledStrip = nullptr) {
+        if (!instance) {
+            instance = new Lc2AllPanels(startIndex, ledStrip);
+        }
+        return instance;
+    }
+
+private:
+    /**
+     * @brief Private constructor to enforce singleton pattern
+     * @param startIndex The starting index for this panel's LEDs on the strip
+     * @param ledStrip Pointer to the LED strip array
+     * @see This method is called by the public getInstance() if and only if no instance exists yet
+     */
+    Lc2AllPanels(int startIndex, CRGB* ledStrip) {
+        panelStartIndex = startIndex;
+        this->ledStrip = ledStrip;
+        ledCount = LC2_ALL_PANELS_LED_COUNT;
+        ledTable = lc2AllPanelsLedTable;
+    }
+
+    // Static callback functions for DCS-BIOS
+    // NIL
+
+    // Instance data
+    static Lc2AllPanels* instance;
+};
+
+// Initialize static instance pointer
+Lc2AllPanels* Lc2AllPanels::instance = nullptr;
+
+#endif 


### PR DESCRIPTION
…readme

## Description

Moved JETT SEL placard from LIP 2 to LIP 1 channel according to interconnect. 
Added LED count constants for readability.
Improved readme for ease of unterstanding. 

Closes #<issue number>

### Dependencies
* List any dependencies that are required for this change, including a full list of libraries required, especially if it is a new or otherwise unused library in the OpenHornet software.

### Type of change
- [ ] New software module (new software module for slave)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update outside of the automatically-generated Doxygen documentation.

### Checklist:
- [X] My code follows the [style guidelines](https://jrsteensen.github.io/OpenHornet-Software/d4/d46/md__2github_2workspace_2_s_t_y_l_e_g_u_i_d_e.html) of this project
- [X] [I have complied with the software manual](https://jrsteensen.github.io/OpenHornet-Software/d7/d78/md__software_manual.html) for this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code fully with Doxygen compatible comments, particularly in hard-to-understand areas
- [X] I have made corresponding changes to non-Doxygen generated documentation
- [ ] I have ran Doxygen locally, and it builds the docs successfully
- [X] My changes generate no errors on compile in Arduino IDE
- [X] My changes generate no new warnings on compile in Arduino IDE
- [X] Any dependent changes have been merged and published in downstream modules


### How Has This Been Tested?

- [X] I have tested the sketch in-circuit in DCS with DCS-BIOS and outputs (displays, LEDs, etc.) function as expected. 
- [X] I have tested the sketch in-circuit in DCS with DCS-BIOS and HID inputs (switches, pots, etc.) function as expected, with switches moving the correct direction.
- [X] I have tested the sketch in-circuit in DCS with DCS-BIOS and any logic in the sketch has been tested and functions as expected.
- [ ] This code has not yet been tested in-circuit.
- [ ] This code has not yet been tested in DCS-BIOS.

#### Description of Testing
Tested on my machine and several users

#### Test Configuration
* Firmware version:
* Hardware:
* Toolchain:
* SDK: