### PR TITLE
Update 4A2A1-LDG_GEAR_PANEL.ino

### DIFF
--- a/embedded/OH4_Left_Console/4A2A1-LDG_GEAR_PANEL/4A2A1-LDG_GEAR_PANEL.ino
+++ b/embedded/OH4_Left_Console/4A2A1-LDG_GEAR_PANEL/4A2A1-LDG_GEAR_PANEL.ino
@@ -107,24 +107,24 @@ DcsBios::Switch2Pos emergencyGearRotate("EMERGENCY_GEAR_ROTATE", LG_EMERG);
 DcsBios::Switch2Pos gearDownlockOverrideBtn("GEAR_DOWNLOCK_OVERRIDE_BTN", LG_ORIDE);
 DcsBios::Switch2Pos gearLever("GEAR_LEVER", LG_LIMIT);
 DcsBios::Switch2Pos gearSilenceBtn("GEAR_SILENCE_BTN", LG_WARN);
-DcsBios::LED landingGearHandleLt(0x747e, 0x0800, LG_LED);
+DcsBios::LED landingGearHandleLt(FA_18C_hornet_LANDING_GEAR_HANDLE_LT_AM, LG_LED);
 
 // DCSBios reads to save airplane state information.
 void onExtWowLeftChange(unsigned int newValue) {
   wowLeft = newValue;
-} DcsBios::IntegerBuffer extWowLeftBuffer(0x74d8, 0x0100, 8, onExtWowLeftChange);
+} DcsBios::IntegerBuffer extWowLeftBuffer(FA_18C_hornet_EXT_WOW_LEFT, onExtWowLeftChange);
 
 void onExtWowNoseChange(unsigned int newValue) {
   wowNose = newValue;
-} DcsBios::IntegerBuffer extWowNoseBuffer(0x74d6, 0x4000, 14, onExtWowNoseChange);
+} DcsBios::IntegerBuffer extWowNoseBuffer(FA_18C_hornet_EXT_WOW_NOSE, onExtWowNoseChange);
 
 void onExtWowRightChange(unsigned int newValue) {
   wowRight = newValue;
-} DcsBios::IntegerBuffer extWowRightBuffer(0x74d6, 0x8000, 15, onExtWowRightChange);
+} DcsBios::IntegerBuffer extWowRightBuffer(FA_18C_hornet_EXT_WOW_RIGHT, onExtWowRightChange);
 
 void onGearDownlockOverrideBtnChange(unsigned int newValue) {
   downLockOverride = newValue;
-} DcsBios::IntegerBuffer gearDownlockOverrideBtnBuffer(0x747e, 0x4000, 14, onGearDownlockOverrideBtnChange);
+} DcsBios::IntegerBuffer gearDownlockOverrideBtnBuffer(FA_18C_hornet_GEAR_DOWNLOCK_OVERRIDE_BTN, onGearDownlockOverrideBtnChange);
 
 /**
 * Arduino Setup Function


### PR DESCRIPTION


## Description

Updated landing gear panel to use the defines in Addresses.h vs the hardcoded values.  If the addresses change in DCS, the code should continue to work for newer versions of DCS Bios.  There was one report of the SAI Cage button leading to erratic behavior on the LDG Solenoid, which could've potentially have been an address change.  It wasn't the case since DCS Bios 0.3.11 has the same address as the prior version of this sketch under DCS Bios 0.3.9.

Closes #

### Dependencies
* List any dependencies that are required for this change, including a full list of libraries required, especially if it is a new or otherwise unused library in the OpenHornet software.

### Type of change
- [ ] New software module (new software module for slave)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update outside of the automatically-generated Doxygen documentation.

### Checklist:
- [x] My code follows the [style guidelines](https://jrsteensen.github.io/OpenHornet-Software/d4/d46/md__2github_2workspace_2_s_t_y_l_e_g_u_i_d_e.html) of this project
- [x] [I have complied with the software manual](https://jrsteensen.github.io/OpenHornet-Software/d7/d78/md__software_manual.html) for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code fully with Doxygen compatible comments, particularly in hard-to-understand areas
- [x] I have made corresponding changes to non-Doxygen generated documentation
- [x] I have ran Doxygen locally, and it builds the docs successfully
- [x] My changes generate no errors on compile in Arduino IDE
- [x] My changes generate no new warnings on compile in Arduino IDE
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] (For sketches only) This sketch complies with OH-INTERCONNECT v**<insert version number here>**
- [ ] If this sketch requires additional libraries, [I have added it as a sub-module per the Arduino Libraries section of the Software Manual.](https://jrsteensen.github.io/OpenHornet-Software/d7/d78/md__software_manual.html)

### How Has This Been Tested?

- [x] I have tested the sketch in-circuit in DCS with DCS-BIOS and outputs (displays, LEDs, etc.) function as expected. 
- [ ] I have tested the sketch in-circuit in DCS with DCS-BIOS and HID inputs (switches, pots, etc.) function as expected, with switches moving the correct direction.
- [x] I have tested the sketch in-circuit in DCS with DCS-BIOS and any logic in the sketch has been tested and functions as expected.
- [ ] This code has not yet been tested in-circuit.
- [ ] This code has not yet been tested in DCS-BIOS.

#### Description of Testing
Verified DCS Bios commands continue to work for switch input.  Outputs verified via light test in sim, and weight-on-wheel logic in flight and on the ground.  Validated the LDG override switch works as expected in sim and without the sim running.  Verified that the SAI Cage button (via virtual clicks in sim) do not cause the LDG solenoid to activate allowing a handle movement when jet is on the ground.

#### Test Configuration
* Firmware version: DCS Bios 0.3.11
* Hardware:
* Toolchain:
* SDK: