### PR TITLE
Enable DCSBIOS_RS485_SLAVE_LARGE_BUFFER for the Fire Test Panel

### DIFF
--- a/embedded/OH4_Left_Console/4A3A3-FIRE_TEST_PANEL/4A3A3-FIRE_TEST_PANEL.ino
+++ b/embedded/OH4_Left_Console/4A3A3-FIRE_TEST_PANEL/4A3A3-FIRE_TEST_PANEL.ino
@@ -89,6 +89,13 @@
 #define TXENABLE_PIN 5  ///< Sets TXENABLE_PIN to Arduino Pin 5
 #define UART1_SELECT    ///< Selects UART1 on Arduino for serial communication
 
+/*
+  The following #define tells DCS-BIOS that this RS-485 slave device uses a
+  larger ring buffer size than the default. Required to allow message IDs
+  that are longer than 32 bytes from aircraft such as F/A-18C and F-4E.
+*/
+#define DCSBIOS_RS485_SLAVE_LARGE_BUFFER // Requires DCS-BIOS Arduino Library 0.3.12+, allows for larger message IDs from DCS.
+
 #include "DcsBios.h"
 #include <Stepper.h>
 #include "Adafruit_NeoPixel.h"


### PR DESCRIPTION
to fix RS485 DCS-BIOS messages longer than 32 characters, such as EMERGENCY_PARKING_BRAKE_ROTATE 1.

Note:
* The 32 characters limit includes the null terminator, \0
* This required DCS-Skunkworks/dcs-bios-arduino-library 0.3.12 or later

## Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.

Closes #135

xRefs:
* https://github.com/DCS-Skunkworks/dcs-bios-arduino-library/pull/101

### Dependencies
* List any dependencies that are required for this change, including a full list of libraries required, especially if it is a new or otherwise unused library in the OpenHornet software.

### Type of change
- [ ] New software module (new software module for slave)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update outside of the automatically-generated Doxygen documentation.

### Checklist:
- [x] My code follows the [style guidelines](https://jrsteensen.github.io/OpenHornet-Software/d4/d46/md__2github_2workspace_2_s_t_y_l_e_g_u_i_d_e.html) of this project
- [x] [I have complied with the software manual](https://jrsteensen.github.io/OpenHornet-Software/d7/d78/md__software_manual.html) for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code fully with Doxygen compatible comments, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to non-Doxygen generated documentation
- [ ] I have ran Doxygen locally, and it builds the docs successfully
- [x] My changes generate no errors on compile in Arduino IDE
- [x] My changes generate no new warnings on compile in Arduino IDE
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] (For sketches only) This sketch complies with OH-INTERCONNECT v**15**
- [ ] If this sketch requires additional libraries, [I have added it as a sub-module per the Arduino Libraries section of the Software Manual.](https://jrsteensen.github.io/OpenHornet-Software/d7/d78/md__software_manual.html)

### How Has This Been Tested?

- [ ] I have tested the sketch in-circuit in DCS with DCS-BIOS and outputs (displays, LEDs, etc.) function as expected. 
- [x] I have tested the sketch in-circuit in DCS with DCS-BIOS and HID inputs (switches, pots, etc.) function as expected, with switches moving the correct direction.
- [x] I have tested the sketch in-circuit in DCS with DCS-BIOS and any logic in the sketch has been tested and functions as expected.
- [ ] This code has not yet been tested in-circuit.
- [ ] This code has not yet been tested in DCS-BIOS.

#### Description of Testing
<Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration>

#### Test Configuration
* Firmware version:
* Hardware:
* Toolchain:
* SDK: