### PR TITLE
Set TXENABLE_PIN to 2 for the COMM panel to work properly as

### DIFF
--- a/embedded/OH4_Left_Console/4A7A1-COMM_PANEL/4A7A1-COMM_PANEL.ino
+++ b/embedded/OH4_Left_Console/4A7A1-COMM_PANEL/4A7A1-COMM_PANEL.ino
@@ -32,9 +32,9 @@
 
 /**
  * @file 4A7A1-COMM_PANEL.ino
- * @author Arribe
+ * @author Arribe, Ash
  * @date 03.03.2024
- * @version 0.0.1
+ * @version 0.1.0
  * @copyright Copyright 2016-2024 OpenHornet. Licensed under the Apache License, Version 2.0.
  * @brief @brief Controls the COMM panel & ANT SEL panel.
  *
@@ -89,26 +89,23 @@
  * 25  | ILS Channel 18
  * 22  | ILS Channel 19
  * 23  | ILS Channel 20
- * 
+ *
  * @brief The following #define tells DCS-BIOS that this is a RS-485 slave device.
  * It also sets the address of this slave device. The slave address should be
  * between 1 and 126 and must be unique among all devices on the same bus.
  *
- * @bug RS485 currently does not work with the Pro Micro (32U4), Fails to compile.
-   @todo When the RS485 is resolved for the Pro Micro finish coding for RS485 on the Comm Panel's Mega.
-
    #define DCSBIOS_RS485_SLAVE 8 ///DCSBios RS485 Bus Address, once bug resolved move line below comment.
 */
 
 /**
  * Check if we're on a Mega328 or Mega2560 and define the correct
  * serial interface
- * 
+ *
  */
 #if defined(__AVR_ATmega328P__) || defined(__AVR_ATmega2560__)
 #define DCSBIOS_IRQ_SERIAL ///< This enables interrupt-driven serial communication for DCS-BIOS. (Only used with the ATmega328P or ATmega2560 microcontrollers.)
 #else
-#define DCSBIOS_DEFAULT_SERIAL ///< This enables the default serial communication for DCS-BIOS. (Used with all other microcontrollers than the ATmega328P or ATmega2560.)  
+#define DCSBIOS_DEFAULT_SERIAL ///< This enables the default serial communication for DCS-BIOS. (Used with all other microcontrollers than the ATmega328P or ATmega2560.)
 #endif
 
 #ifdef __AVR__
@@ -116,11 +113,13 @@
 #endif
 
 /**
- * The Arduino pin that is connected to the
- * RE and DE pins on the RS-485 transceiver.
-*/
-#define UART1_TXENABLE_PIN 1 ///< Sets TXENABLE_PIN to Arduino Mega pin Tx0
-#define UART1_SELECT ///< Selects UART1 on Arduino for serial communication
+ * @brief Arduino pin connected to the RS-485 transceiver /RE and DE enable pins.
+ *
+ * DCS-BIOS uses this pin when the sketch is configured as an RS485 slave.
+ * It is ignored by direct USB serial modes.
+ */
+#define TXENABLE_PIN 2
+
 
 #include "DcsBios.h"
 


### PR DESCRIPTION
RS485 bus slave

## Description

Mega 2560 with RS485 Slave needs the define of `TXENABLE_PIN` as `2`.

[Context](https://discord.com/channels/392833351238811648/1046812440354103296/1464039184875389020)

Closes #<issue number>

### Dependencies
* List any dependencies that are required for this change, including a full list of libraries required, especially if it is a new or otherwise unused library in the OpenHornet software.

### Type of change
- [ ] New software module (new software module for slave)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update outside of the automatically-generated Doxygen documentation.

### Checklist:
- [x] [I have complied with the software manual]((https://jrsteensen.github.io/OpenHornet-Software/d7/d78/md__software_manual.html)) for this project, to include style requirements
- [x] I have incremented the version of the program in the header, using semantic versioning (Do not increment major version (x.0.0) until post-1.0 package release)
- [x] I have added myself as a co-author in the program header
- [x] I have performed a self-review of my own code
- [x] I have commented my code fully with Doxygen compatible comments, particularly in hard-to-understand areas, and reviewed previous comments in the code.
- [ ] I have made corresponding changes to non-Doxygen generated documentation
- [ ] I have ran Doxygen locally, and it builds the docs successfully
- [x] My changes generate no errors on compile in Arduino IDE
- [x] My changes generate no new warnings on compile in Arduino IDE
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] (For sketches only) This sketch complies with OH-INTERCONNECT v**15**
- [ ] If this sketch requires additional libraries, [I have added it as a sub-module per the Arduino Libraries section of the Software Manual.](https://jrsteensen.github.io/OpenHornet-Software/d7/d78/md__software_manual.html)

### How Has This Been Tested?

- [ ] I have tested the sketch in-circuit in DCS with DCS-BIOS and outputs (displays, LEDs, etc.) function as expected. 
- [x] I have tested the sketch in-circuit in DCS with DCS-BIOS and HID inputs (switches, pots, etc.) function as expected, with switches moving the correct direction.
- [x] I have tested the sketch in-circuit in DCS with DCS-BIOS and any logic in the sketch has been tested and functions as expected.
- [ ] This code has not yet been tested in-circuit.
- [ ] This code has not yet been tested in DCS-BIOS.

#### Description of Testing
<Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration>

#### Test Configuration
* Firmware version:
* Hardware:
* Toolchain:
* SDK:
