### PR TITLE
Remove the bug message for RS485 Slave for Pro Micro

### DIFF
--- a/embedded/OH1_Upper_Instrument_Panel/1A2-MASTER_ARM_PANEL/1A2-MASTER_ARM_PANEL.ino
+++ b/embedded/OH1_Upper_Instrument_Panel/1A2-MASTER_ARM_PANEL/1A2-MASTER_ARM_PANEL.ino
@@ -32,9 +32,9 @@
 
 /**
  * @file 1A2-MASTER_ARM_PANEL.ino
- * @author Sandra Carroll (<a href="mailto:smgvbest@gmail.com">smgvbest@gmail.com</a>), Arribe
+ * @author Sandra Carroll (<a href="mailto:smgvbest@gmail.com">smgvbest@gmail.com</a>), Arribe, Ash
  * @date 3.02.2024
- * @version 0.0.2
+ * @version 0.1.0
  * @copyright Copyright 2016-2024 OpenHornet. Licensed under the Apache License, Version 2.0.
  * @brief Controls the MASTER ARM panel. 
  *
@@ -59,8 +59,7 @@
  * It also sets the address of this slave device. The slave address should be
  * between 1 and 126 and must be unique among all devices on the same bus.
  *
- * @bug Currently does not work with the Pro Micro (32U4), Fails to compile. 
- *   #define DCSBIOS_RS485_SLAVE 1 ///DCSBios RS485 Bus Address, once bug resolved move line below comment.
+ *   #define DCSBIOS_RS485_SLAVE 1 ///DCSBios RS485 Bus Address
  */
 
 /**

--- a/embedded/OH1_Upper_Instrument_Panel/1A6-SPIN_RCVY_PANEL/1A6-SPIN_RCVY_PANEL.ino
+++ b/embedded/OH1_Upper_Instrument_Panel/1A6-SPIN_RCVY_PANEL/1A6-SPIN_RCVY_PANEL.ino
@@ -32,9 +32,9 @@
 
 /**
  * @file 1A6-SPIN_RCVY_PANEL.ino
- * @author Arribe
+ * @author Arribe, Ash
  * @date 03.02.2024
- * @version 0.0.3
+ * @version 0.1.0
  * @copyright Copyright 2016-2024 OpenHornet. Licensed under the Apache License, Version 2.0.
  * @brief Controls the SPIN RCVY panel.
  *
@@ -57,9 +57,7 @@
  * It also sets the address of this slave device. The slave address should be
  * between 1 and 126 and must be unique among all devices on the same bus.
  *
- * @bug Currently does not work with the Pro Micro (32U4), Fails to compile. 
- *
- *  #define DCSBIOS_RS485_SLAVE 1 ///DCSBios RS485 Bus Address, once bug resolved move line below comment.
+ *  #define DCSBIOS_RS485_SLAVE 1 ///DCSBios RS485 Bus Address
  */
 
 /**

--- a/embedded/OH1_Upper_Instrument_Panel/1A7-HUD_PANEL/1A7-HUD_PANEL.ino
+++ b/embedded/OH1_Upper_Instrument_Panel/1A7-HUD_PANEL/1A7-HUD_PANEL.ino
@@ -32,9 +32,9 @@
 
 /**
  * @file 1A7-HUD_PANEL.ino
- * @author Arribe
+ * @author Arribe, Ash
  * @date 02.29.2024
- * @version 0.0.1
+ * @version 0.1.0
  * @copyright Copyright 2016-2024 OpenHornet. Licensed under the Apache License, Version 2.0.
  * @brief Controls the HUD panel.
  *
@@ -64,9 +64,7 @@
 * It also sets the address of this slave device. The slave address should be
 * between 1 and 126 and must be unique among all devices on the same bus.
 *
-* @bug Currently does not work with the Pro Micro (32U4), Fails to compile. 
-*
-*  #define DCSBIOS_RS485_SLAVE 1 ///DCSBios RS485 Bus Address, once bug resolved move line below comment.
+*  #define DCSBIOS_RS485_SLAVE 1 ///DCSBios RS485 Bus Address
 */
 
 /**

--- a/embedded/OH2_Lower_Instrument_Panel/2A2A1-LEFT_LIP_MODULE/2A2A1-LEFT_LIP_MODULE.ino
+++ b/embedded/OH2_Lower_Instrument_Panel/2A2A1-LEFT_LIP_MODULE/2A2A1-LEFT_LIP_MODULE.ino
@@ -32,9 +32,9 @@
 
 /**
  * @file 2A2A1-LEFT_LIP_MODULE.ino
- * @author Arribe
+ * @author Arribe, Ash
  * @date 03.21.2024
- * @version 0.0.1
+ * @version 0.1.0
  * @copyright Copyright 2016-2024 OpenHornet. Licensed under the Apache License, Version 2.0.
  * @brief Controls the LEFT LIP module.
  *
@@ -69,9 +69,7 @@
  * It also sets the address of this slave device. The slave address should be
  * between 1 and 126 and must be unique among all devices on the same bus.
  *
- * @bug Currently does not work with the Pro Micro (32U4), Fails to compile. 
-
-   #define DCSBIOS_RS485_SLAVE 1 ///DCSBios RS485 Bus Address, once bug resolved move line below comment.
+   #define DCSBIOS_RS485_SLAVE 1 ///DCSBios RS485 Bus Address
 */
 
 /**

--- a/embedded/OH2_Lower_Instrument_Panel/2A4A1-RWR_CONTROL_PANEL/2A4A1-RWR_CONTROL_PANEL.ino
+++ b/embedded/OH2_Lower_Instrument_Panel/2A4A1-RWR_CONTROL_PANEL/2A4A1-RWR_CONTROL_PANEL.ino
@@ -32,9 +32,9 @@
 
 /**
  * @file 2A4A1-RWR_CONTROL_PANEL.ino
- * @author Arribe
+ * @author Arribe, Ash
  * @date 03.21.2024
- * @version 0.0.1
+ * @version 0.1.0
  * @copyright Copyright 2016-2024 OpenHornet. Licensed under the Apache License, Version 2.0.
  * @brief Controls the RWR CONTROL panel.
  *
@@ -64,9 +64,7 @@
  * It also sets the address of this slave device. The slave address should be
  * between 1 and 126 and must be unique among all devices on the same bus.
  *
- * @bug Currently does not work with the Pro Micro (32U4), Fails to compile. 
-
-   #define DCSBIOS_RS485_SLAVE 3 ///DCSBios RS485 Bus Address, once bug resolved move line below comment.
+   #define DCSBIOS_RS485_SLAVE 3 ///DCSBios RS485 Bus Address
 */
 
 /**

--- a/embedded/OH3_Center_Tub/3A2A1-SEAT_CONTROLS/3A2A1-SEAT_CONTROLS.ino
+++ b/embedded/OH3_Center_Tub/3A2A1-SEAT_CONTROLS/3A2A1-SEAT_CONTROLS.ino
@@ -32,9 +32,9 @@
 
 /**
  * @file 3A2A1-SEAT_CONTROLS.ino
- * @author Arribe
+ * @author Arribe, Ash
  * @date 03.13.2024
- * @version u.0.0.1 (untested)
+ * @version u.0.1.0 (untested)
  * @copyright Copyright 2016-2024 OpenHornet. Licensed under the Apache License, Version 2.0.
  * @warning This sketch is based on a wiring diagram, and was not yet fully tested on hardware.\n  *The ejection handle pull, seat arm/disarm, and manual release override have been tested on hardware.
  * The seat up/down, and shoulder harness lock/unlock was validated via BORT by observing DCS output values and ensuring those inputs line up with the DCS Bios Switch codes' inputs.*
@@ -62,9 +62,7 @@
  * It also sets the address of this slave device. The slave address should be
  * between 1 and 126 and must be unique among all devices on the same bus.
  *
- * @bug Currently does not work with the Pro Micro (32U4), Fails to compile. 
-
-   #define DCSBIOS_RS485_SLAVE 9 ///DCSBios RS485 Bus Address, once bug resolved move line below comment.
+   #define DCSBIOS_RS485_SLAVE 9 ///DCSBios RS485 Bus Address
 */
 
 /**

--- a/embedded/OH4_Left_Console/4A2A1-LDG_GEAR_PANEL/4A2A1-LDG_GEAR_PANEL.ino
+++ b/embedded/OH4_Left_Console/4A2A1-LDG_GEAR_PANEL/4A2A1-LDG_GEAR_PANEL.ino
@@ -32,9 +32,9 @@
 
 /**
  * @file 4A2A1-LDG_GEAR_PANEL.ino
- * @author Arribe
+ * @author Arribe, Ash
  * @date 2/28/2024
- * @version 0.0.3
+ * @version 0.1.0
  * @copyright Copyright 2016-2024 OpenHornet. Licensed under the Apache License, Version 2.0.
  * @brief Controls the LDG GEAR panel.
  *
@@ -58,8 +58,6 @@
  * @brief The following #define tells DCS-BIOS that this is a RS-485 slave device.
  * It also sets the address of this slave device. The slave address should be
  * between 1 and 126 and must be unique among all devices on the same bus.
- *
- * @bug Currently does not work with the Pro Micro (32U4), Fails to compile. 
  *
  // #define DCSBIOS_RS485_SLAVE 1
 */

--- a/embedded/OH4_Left_Console/4A3A1-SELECT_JETT_PANEL/4A3A1-SELECT_JETT_PANEL.ino
+++ b/embedded/OH4_Left_Console/4A3A1-SELECT_JETT_PANEL/4A3A1-SELECT_JETT_PANEL.ino
@@ -34,7 +34,7 @@
  * @file 4A3A1-SELECT_JETT_PANEL.ino
  * @author Arribe, Ash
  * @date 03.24.2026
- * @version 0.1.0
+ * @version 0.2.0
  * @copyright Copyright 2016-2024 OpenHornet. Licensed under the Apache License, Version 2.0.
  * @brief Controls the SELECT JETT panel.
  *
@@ -66,9 +66,7 @@
  * It also sets the address of this slave device. The slave address should be
  * between 1 and 126 and must be unique among all devices on the same bus.
  *
- * @bug Currently does not work with the Pro Micro (32U4), Fails to compile. 
- *
-//#define DCSBIOS_RS485_SLAVE 1 ///DCSBios RS485 Bus Address, once bug resolved move line below comment.
+//#define DCSBIOS_RS485_SLAVE 1 ///DCSBios RS485 Bus Address
 */
 
 /**

--- a/embedded/OH4_Left_Console/4A3A3-FIRE_TEST_PANEL/4A3A3-FIRE_TEST_PANEL.ino
+++ b/embedded/OH4_Left_Console/4A3A3-FIRE_TEST_PANEL/4A3A3-FIRE_TEST_PANEL.ino
@@ -34,7 +34,7 @@
  * @file 4A3A3-FIRE_TEST_PANEL.ino
  * @author Arribe, Ash
  * @date 03.30.2024
- * @version 0.1.0
+ * @version 0.2.0
  * @copyright Copyright 2016-2024 OpenHornet. Licensed under the Apache License, Version 2.0.
  * @brief Controls the BRK PRESS gauge, BRAKE handle &amp; FIRE TEST panel.
  *
@@ -62,9 +62,7 @@
  * It also sets the address of this slave device. The slave address should be
  * between 1 and 126 and must be unique among all devices on the same bus.
  *
- * @bug Currently does not work with the Pro Micro (32U4), Fails to compile. 
-
-   #define DCSBIOS_RS485_SLAVE 3 ///DCSBios RS485 Bus Address, once bug resolved move line below comment.
+   #define DCSBIOS_RS485_SLAVE 3 ///DCSBios RS485 Bus Address
 */
 
 /**

--- a/embedded/OH4_Left_Console/4A4A2-EXT_LIGHTS_PANEL/4A4A2-EXT_LIGHTS_PANEL.ino
+++ b/embedded/OH4_Left_Console/4A4A2-EXT_LIGHTS_PANEL/4A4A2-EXT_LIGHTS_PANEL.ino
@@ -32,9 +32,9 @@
 
 /**
  * @file 4A4A2-EXT_LIGHTS_PANEL.ino
- * @author Arribe
+ * @author Arribe, Ash
  * @date 03.03.2024
- * @version 0.0.1
+ * @version 0.1.0
  * @copyright Copyright 2016-2024 OpenHornet. Licensed under the Apache License, Version 2.0.
  * @brief Controls the EXT LIGHTS panel, GEN TIE panel & ECM DISP switch.
  *
@@ -59,9 +59,7 @@
  * It also sets the address of this slave device. The slave address should be
  * between 1 and 126 and must be unique among all devices on the same bus.
  *
- * @bug Currently does not work with the Pro Micro (32U4), Fails to compile. 
-
-   #define DCSBIOS_RS485_SLAVE 4 ///DCSBios RS485 Bus Address, once bug resolved move line below comment.
+   #define DCSBIOS_RS485_SLAVE 4 ///DCSBios RS485 Bus Address
 */
 
 /**

--- a/embedded/OH4_Left_Console/4A5A1-FUEL_PANEL/4A5A1-FUEL_PANEL.ino
+++ b/embedded/OH4_Left_Console/4A5A1-FUEL_PANEL/4A5A1-FUEL_PANEL.ino
@@ -34,7 +34,7 @@
  * @file 4A5A1-FUEL_PANEL.ino
  * @author Arribe, Ash
  * @date 03.24.2026
- * @version 0.1.0
+ * @version 0.2.0
  * @copyright Copyright 2016-2024 OpenHornet. Licensed under the Apache License, Version 2.0.
  * @brief Controls the FUEL panel.
  *
@@ -59,9 +59,7 @@
  * It also sets the address of this slave device. The slave address should be
  * between 1 and 126 and must be unique among all devices on the same bus.
  *
- * @bug Currently does not work with the Pro Micro (32U4), Fails to compile. 
-
-   #define DCSBIOS_RS485_SLAVE 6 ///DCSBios RS485 Bus Address, once bug resolved move line below comment.
+   #define DCSBIOS_RS485_SLAVE 6 ///DCSBios RS485 Bus Address
 */
 
 /**

--- a/embedded/OH4_Left_Console/4A5A2-APU_PANEL/4A5A2-APU_PANEL.ino
+++ b/embedded/OH4_Left_Console/4A5A2-APU_PANEL/4A5A2-APU_PANEL.ino
@@ -34,7 +34,7 @@
  * @file 4A5A2-APU_PANEL.ino
  * @author Arribe, Ash
  * @date 03.24.2026
- * @version 0.1.0
+ * @version 0.2.0
  * @copyright Copyright 2016-2024 OpenHornet. Licensed under the Apache License, Version 2.0.
  * @brief Controls the APU panel & L CIRCUIT BREAKERS.
  *
@@ -62,9 +62,7 @@
  * It also sets the address of this slave device. The slave address should be
  * between 1 and 126 and must be unique among all devices on the same bus.
  *
- * @bug Currently does not work with the Pro Micro (32U4), Fails to compile. 
-
-   #define DCSBIOS_RS485_SLAVE 5 ///DCSBios RS485 Bus Address, once bug resolved move line below comment.
+   #define DCSBIOS_RS485_SLAVE 5 ///DCSBios RS485 Bus Address
 */
 
 /**

--- a/embedded/OH4_Left_Console/4A6A1-FCS_PANEL/4A6A1-FCS_PANEL.ino
+++ b/embedded/OH4_Left_Console/4A6A1-FCS_PANEL/4A6A1-FCS_PANEL.ino
@@ -34,7 +34,7 @@
  * @file 4A6A1-FCS_PANEL.ino
  * @author Arribe, Ash
  * @date 03.04.2024
- * @version u.0.1.0 (partially tested)
+ * @version u.0.2.0 (partially tested)
  * @copyright Copyright 2016-2024 OpenHornet. Licensed under the Apache License, Version 2.0.
  * @warning This sketch is based on a wiring diagram, but the Rudder trim speed is set to full-on.  
  * The rudder trim speed is untested, the test hardware was wired directly to always run at full power.
@@ -64,9 +64,7 @@
  * It also sets the address of this slave device. The slave address should be
  * between 1 and 126 and must be unique among all devices on the same bus.
  *
- * @bug Currently does not work with the Pro Micro (32U4), Fails to compile. 
-
-   #define DCSBIOS_RS485_SLAVE 7 ///DCSBios RS485 Bus Address, once bug resolved move line below comment.
+   #define DCSBIOS_RS485_SLAVE 7 ///DCSBios RS485 Bus Address
 */
 
 /**

--- a/embedded/OH4_Left_Console/4A7A1-COMM_PANEL/4A7A1-COMM_PANEL.ino
+++ b/embedded/OH4_Left_Console/4A7A1-COMM_PANEL/4A7A1-COMM_PANEL.ino
@@ -34,7 +34,7 @@
  * @file 4A7A1-COMM_PANEL.ino
  * @author Arribe, Ash
  * @date 03.03.2024
- * @version 0.1.0
+ * @version 0.2.0
  * @copyright Copyright 2016-2024 OpenHornet. Licensed under the Apache License, Version 2.0.
  * @brief @brief Controls the COMM panel & ANT SEL panel.
  *
@@ -94,7 +94,7 @@
  * It also sets the address of this slave device. The slave address should be
  * between 1 and 126 and must be unique among all devices on the same bus.
  *
-   #define DCSBIOS_RS485_SLAVE 8 ///DCSBios RS485 Bus Address, once bug resolved move line below comment.
+   #define DCSBIOS_RS485_SLAVE 8 ///DCSBios RS485 Bus Address
 */
 
 /**

--- a/embedded/OH4_Left_Console/4A7A2-OBOGS_PANEL/4A7A2-OBOGS_PANEL.ino
+++ b/embedded/OH4_Left_Console/4A7A2-OBOGS_PANEL/4A7A2-OBOGS_PANEL.ino
@@ -32,9 +32,9 @@
 
 /**
  * @file 4A7A2-OBOGS_PANEL.ino
- * @author Arribe
+ * @author Arribe, Ash
  * @date 03.05.2024
- * @version u.0.0.1 (partially untested)
+ * @version u.0.1.0 (partially untested)
  * @copyright Copyright 2016-2024 OpenHornet. Licensed under the Apache License, Version 2.0.
  * @warning This sketch is based on a wiring diagram for the NUC Switch, but it was not yet tested on hardware.  The NUC Switch is a simple 2 position DCSBios switch. It is highly likely it will work fine.
  * All other switches were tested successfully.
@@ -60,9 +60,7 @@
  * It also sets the address of this slave device. The slave address should be
  * between 1 and 126 and must be unique among all devices on the same bus.
  *
- * @bug Currently does not work with the Pro Micro (32U4), Fails to compile. 
-
-   #define DCSBIOS_RS485_SLAVE 10 ///DCSBios RS485 Bus Address, once bug resolved move line below comment.
+   #define DCSBIOS_RS485_SLAVE 10 ///DCSBios RS485 Bus Address
 */
 
 /**

--- a/embedded/OH5_Right_Console/5A10-DEFOG_PANEL/5A10-DEFOG_PANEL.ino
+++ b/embedded/OH5_Right_Console/5A10-DEFOG_PANEL/5A10-DEFOG_PANEL.ino
@@ -34,7 +34,7 @@
  * @file 5A10-DEFOG_PANEL.ino
  * @author Arribe, Ash
  * @date 03.24.2026
- * @version 0.1.0
+ * @version 0.2.0
  * @copyright Copyright 2016-2024 OpenHornet. Licensed under the Apache License, Version 2.0.
  **
  * @brief Controls the DEFOG panel, R CRKT BRKRs & CANOPY module.
@@ -69,9 +69,7 @@
  * It also sets the address of this slave device. The slave address should be
  * between 1 and 126 and must be unique among all devices on the same bus.
  *
- * @bug Currently does not work with the Pro Micro (32U4), Fails to compile. 
- *
- * #define DCSBIOS_RS485_SLAVE 9 ///DCSBios RS485 Bus Address, once bug resolved move line below comment.
+ * #define DCSBIOS_RS485_SLAVE 9 ///DCSBios RS485 Bus Address
 */
 
 /**

--- a/embedded/OH5_Right_Console/5A5A1-ECS_PANEL/5A5A1-ECS_PANEL.ino
+++ b/embedded/OH5_Right_Console/5A5A1-ECS_PANEL/5A5A1-ECS_PANEL.ino
@@ -34,7 +34,7 @@
  * @file 5A5A1-ECS_PANEL.ino
  * @author Arribe, Ash
  * @date 03.24.2026
- * @version 0.1.0
+ * @version 0.2.0
  * @copyright Copyright 2016-2024 OpenHornet. Licensed under the Apache License, Version 2.0.
  * @brief Controls the ECS panel.
  *
@@ -67,9 +67,7 @@
  * It also sets the address of this slave device. The slave address should be
  * between 1 and 126 and must be unique among all devices on the same bus.
  *
- * @bug Currently does not work with the Pro Micro (32U4), Fails to compile. 
-
-   #define DCSBIOS_RS485_SLAVE 4 ///DCSBios RS485 Bus Address, once bug resolved move line below comment.
+   #define DCSBIOS_RS485_SLAVE 4 ///DCSBios RS485 Bus Address
 */
 
 /**

--- a/embedded/OH5_Right_Console/5A6A1-INTR_LT_PANEL/5A6A1-INTR_LT_PANEL.ino
+++ b/embedded/OH5_Right_Console/5A6A1-INTR_LT_PANEL/5A6A1-INTR_LT_PANEL.ino
@@ -32,9 +32,9 @@
 
 /**
  * @file 5A6A1-INTR_LT_PANEL.ino
- * @author Arribe
+ * @author Arribe, Ash
  * @date 03.11.2024
- * @version 0.0.1
+ * @version 0.1.0
  * @copyright Copyright 2016-2024 OpenHornet. Licensed under the Apache License, Version 2.0.
  * @brief Controls the INTR LT panel.
  *
@@ -60,9 +60,7 @@
  * It also sets the address of this slave device. The slave address should be
  * between 1 and 126 and must be unique among all devices on the same bus.
  *
- * @bug Currently does not work with the Pro Micro (32U4), Fails to compile. 
-
-   #define DCSBIOS_RS485_SLAVE 5 ///DCSBios RS485 Bus Address, once bug resolved move line below comment.
+   #define DCSBIOS_RS485_SLAVE 5 ///DCSBios RS485 Bus Address
 */
 
 /**

--- a/embedded/OH5_Right_Console/5A7A1-SNSR_PANEL/5A7A1-SNSR_PANEL.ino
+++ b/embedded/OH5_Right_Console/5A7A1-SNSR_PANEL/5A7A1-SNSR_PANEL.ino
@@ -34,7 +34,7 @@
  * @file 5A7A1-SNSR_PANEL.ino
  * @author Arribe, Ash
  * @date 03.24.2026
- * @version 0.1.0
+ * @version 0.2.0
  * @copyright Copyright 2016-2024 OpenHornet. Licensed under the Apache License, Version 2.0.
  * @brief Controls the SNSR panel.
  *
@@ -73,9 +73,7 @@
  * It also sets the address of this slave device. The slave address should be
  * between 1 and 126 and must be unique among all devices on the same bus.
  *
- * @bug Currently does not work with the Pro Micro (32U4), Fails to compile. 
- *
-   #define DCSBIOS_RS485_SLAVE 6 ///DCSBios RS485 Bus Address, once bug resolved move line below comment.
+   #define DCSBIOS_RS485_SLAVE 6 ///DCSBios RS485 Bus Address
 */
 
 /**

--- a/embedded/OH5_Right_Console/5A8A1-SIM_CNTL_PANEL/5A8A1-SIM_CNTL_PANEL.ino
+++ b/embedded/OH5_Right_Console/5A8A1-SIM_CNTL_PANEL/5A8A1-SIM_CNTL_PANEL.ino
@@ -32,8 +32,9 @@
 
 /**
  * @file 5A8A1-SIM_CNTL_PANEL.ino
- * @author Arribe
+ * @author Arribe, Ash
  * @date 03.08.2024
+ * @version 0.1.0
  * @copyright Copyright 2016-2024 OpenHornet. Licensed under the Apache License, Version 2.0.
  * @brief Controls the SIM CNTL panel.
  *
@@ -70,9 +71,7 @@
  * It also sets the address of this slave device. The slave address should be
  * between 1 and 126 and must be unique among all devices on the same bus.
  *
- * @bug Currently does not work with the Pro Micro (32U4), Fails to compile. 
-
-   #define DCSBIOS_RS485_SLAVE 7 ///DCSBios RS485 Bus Address, once bug resolved move line below comment.
+   #define DCSBIOS_RS485_SLAVE 7 ///DCSBios RS485 Bus Address
 */
 
 /**

--- a/embedded/OH5_Right_Console/5A9A1-KY58_PANEL/5A9A1-KY58_PANEL.ino
+++ b/embedded/OH5_Right_Console/5A9A1-KY58_PANEL/5A9A1-KY58_PANEL.ino
@@ -32,9 +32,9 @@
 
 /**
  * @file 5A9A1-KY58_PANEL.ino
- * @author Arribe
+ * @author Arribe, Ash
  * @date 03.10.2024
- * @version 0.0.1
+ * @version 0.1.0
  * @copyright Copyright 2016-2024 OpenHornet. Licensed under the Apache License, Version 2.0.
  * @brief Controls the KY58 panel.
  *
@@ -66,9 +66,7 @@
  * It also sets the address of this slave device. The slave address should be
  * between 1 and 126 and must be unique among all devices on the same bus.
  *
- * @bug Currently does not work with the Pro Micro (32U4), Fails to compile. 
-
-   #define DCSBIOS_RS485_SLAVE 8 ///DCSBios RS485 Bus Address, once bug resolved move line below comment.
+   #define DCSBIOS_RS485_SLAVE 8 ///DCSBios RS485 Bus Address
 */
 
 /**


### PR DESCRIPTION
Fix #146

## Description

Remove the bug message for RS485 Slave for Pro Micro, since this has been fixed long time ago and all the RS485 slaves are working properly.

List this as new feature but it's actually just doc/comment update.

Closes #146

### Dependencies
* List any dependencies that are required for this change, including a full list of libraries required, especially if it is a new or otherwise unused library in the OpenHornet software.

### Type of change
- [ ] New software module (new software module for slave)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update outside of the automatically-generated Doxygen documentation.

### Checklist:
- [x] [I have complied with the software manual]((https://jrsteensen.github.io/OpenHornet-Software/d7/d78/md__software_manual.html)) for this project, to include style requirements
- [x] I have incremented the version of the program in the header, using semantic versioning (Do not increment major version (x.0.0) until post-1.0 package release)
- [x] I have added myself as a co-author in the program header
- [x] I have performed a self-review of my own code
- [ ] I have commented my code fully with Doxygen compatible comments, particularly in hard-to-understand areas, and reviewed previous comments in the code.
- [ ] I have made corresponding changes to non-Doxygen generated documentation
- [ ] I have ran Doxygen locally, and it builds the docs successfully
- [ ] My changes generate no errors on compile in Arduino IDE
- [ ] My changes generate no new warnings on compile in Arduino IDE
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] (For sketches only) This sketch complies with OH-INTERCONNECT v**15**
- [ ] If this sketch requires additional libraries, [I have added it as a sub-module per the Arduino Libraries section of the Software Manual.](https://jrsteensen.github.io/OpenHornet-Software/d7/d78/md__software_manual.html)

### How Has This Been Tested?

- [ ] I have tested the sketch in-circuit in DCS with DCS-BIOS and outputs (displays, LEDs, etc.) function as expected. 
- [ ] I have tested the sketch in-circuit in DCS with DCS-BIOS and HID inputs (switches, pots, etc.) function as expected, with switches moving the correct direction.
- [ ] I have tested the sketch in-circuit in DCS with DCS-BIOS and any logic in the sketch has been tested and functions as expected.
- [ ] This code has not yet been tested in-circuit.
- [ ] This code has not yet been tested in DCS-BIOS.

#### Description of Testing
<Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration>

#### Test Configuration
* Firmware version:
* Hardware:
* Toolchain:
* SDK:
