### PR TITLE
Change LED update countdown to time-based ISO loop-based.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ docs/html
 release/
 embedded/**/build/
 .cursorrules
+embedded/OH2_Lower_Instrument_Panel/2A13-BACKLIGHT_CONTROLLER/FASTLED_ISSUE_ANALYSIS.md

--- a/embedded/OH2_Lower_Instrument_Panel/2A13-BACKLIGHT_CONTROLLER/2A13-BACKLIGHT_CONTROLLER.ino
+++ b/embedded/OH2_Lower_Instrument_Panel/2A13-BACKLIGHT_CONTROLLER/2A13-BACKLIGHT_CONTROLLER.ino
@@ -60,7 +60,15 @@
  *          | SDA | TEMP SNSR                     |                  |
  *          | SCL | TEMP SNSR                     |                  |
  *          | 2   | J12 & J13 Cooling fan headers |                  |
- *  
+ * 
+ * 
+ *          **Compilation guide **
+ *          Needs FastLED 3.10.3. Otherwise FastLED serial colludes with 
+ *          DCS-BIOS serial communication and the BLM will not work. Install the library 
+ *          using the following methods:
+ *          - Arduino IDE: Library Manager → FastLED → version dropdown → 3.10.3.
+ *          - arduino-cli: arduino-cli lib install FastLED@3.10.3
+ *          - PlatformIO: lib_deps = fastled/FastLED@3.10.3  
  * 
  *          **User guide**
  *          The BLM will start in mode 1 (DCS-BIOS) mode by default. This means you should
@@ -175,7 +183,11 @@
 #ifdef __AVR__                                                        // Include AVR power library if we're on an AVR
   #include <avr/power.h>
 #endif
-#define FASTLED_INTERRUPT_RETRY_COUNT 1                               // Define the number of retries for FastLED update
+#define FASTLED_ALLOW_INTERRUPTS 0                                    // Keep interrupts off during FastLED.show(). Do not set to 1:
+                                                                      // it risks LEDs lighting in the wrong position, which is
+                                                                      // indistinguishable from a wiring/indexing error. Cost is that
+                                                                      // DCS-BIOS bytes are missed during a show(); DCS-BIOS resends
+                                                                      // every value within ~3.5 s, so the display self-corrects.
 #define DCSBIOS_DISABLE_SERVO                                         // Disable DCS-BIOS servo support (not used)
 
 #include "FastLED.h"

--- a/embedded/OH2_Lower_Instrument_Panel/2A13-BACKLIGHT_CONTROLLER/helpers/Board.h
+++ b/embedded/OH2_Lower_Instrument_Panel/2A13-BACKLIGHT_CONTROLLER/helpers/Board.h
@@ -11,7 +11,7 @@
  *  
  * @file      Board.h
  * @author    Ulukaii
- * @date      08.Nov 2025
+ * @date      18.Jul 2026
  * @version   t 0.3.5
  * @copyright Copyright 2016-2025 OpenHornet. See 2A13-BACKLIGHT_CONTROLLER.ino for details.
  * @brief     The board class is responsible for the physical input/output: catch rotary encoder commands, update LEDs.

--- a/embedded/OH2_Lower_Instrument_Panel/2A13-BACKLIGHT_CONTROLLER/helpers/Board.h
+++ b/embedded/OH2_Lower_Instrument_Panel/2A13-BACKLIGHT_CONTROLLER/helpers/Board.h
@@ -46,7 +46,11 @@ class Board {
 
 private:
 
-    int updCountdown;                                                 //DCS Bios cycle countdown before invoking FastLED.show()
+    int updCountdown;                                                 //Loop countdown before invoking FastLED.show() (MODE_MANUAL / MODE_RAINBOW only)
+    unsigned long lastShowMs;                                         //millis() at the end of the last FastLED.show() (MODE_NORMAL only)
+    static const unsigned long SHOW_INTERVAL_NORMAL_MS = 150;         // Min. gap between FastLED.show() calls in MODE_NORMAL. Interrupts are
+                                                                      // off during show(), so DCS-BIOS data can ONLY be received in this gap.
+                                                                      // Larger = fewer missed updates, but more LED latency. See below.
     static const int MAX_CHANNELS = 10;                               // Maximum number of channels
     static const int MODE_NORMAL = 1;                                 // Normal DCS-BIOS controlled mode
     static const int MODE_MANUAL = 2;                                 // Manual mode - control backlts with rotary encoder
@@ -73,6 +77,7 @@ private:
      */
     Board() {
         updCountdown = 0;                                             // Initialize with 0
+        lastShowMs = 0;                                               // Initialize with 0
         channelCount = 0;                                             // Initialize with 0 channels
         thisHue = 0;                                                  // Initialize with 0
         deltaHue = 3;                                                 // Initialize with 3
@@ -162,20 +167,31 @@ public:
 
     /**
      * @brief Update the physical LED state
+     * @details FastLED.show() takes ~51 ms for ~1700 LEDs and runs with interrupts disabled,
+     *          so no DCS-BIOS data can be received while it runs. The gap between two show()
+     *          calls is therefore the only window in which updates arrive. In MODE_NORMAL that
+     *          gap is timed (SHOW_INTERVAL_NORMAL_MS) rather than counted in loop() iterations:
+     *          a loop iteration is only ~0.1 ms, so counting them gave a listening window of a
+     *          few ms against ~51 ms of deafness, and most updates were missed until DCS-BIOS
+     *          re-sent them on its ~3.5 s sweep. MODE_MANUAL / MODE_RAINBOW do not call
+     *          DcsBios::loop(), so they have nothing to listen for and keep the loop countdown.
      * @see This method is called by loop() in 2A13-BACKLIGHT_CONTROLLER.ino
      */
-    void updateLeds() {                                               
-        if (LedUpdateState::getInstance()->getUpdateFlag()) {
-            int countdownLength = (currentMode == MODE_NORMAL) ? 32 : 8; // Slower refresh in normal mode to collect DCS-Bios updates
-            updCountdown = (updCountdown == 0) ? countdownLength : updCountdown;
-            updCountdown--;                                           // Collect loop() calls into one FastLED.show()
-            if (updCountdown == 0) {                                  // Trigger FastLED.show() at end of countdown
-                cli();
-                FastLED.show();                                       
-                LedUpdateState::getInstance()->setUpdateFlag(false);  // Reset update flag
-                sei();
-            }
+    void updateLeds() {
+        if (!LedUpdateState::getInstance()->getUpdateFlag()) return;  // Nothing changed: no update needed
+
+        if (currentMode == MODE_NORMAL) {                             // Leave a fixed listening window for DCS-BIOS data
+            if (millis() - lastShowMs < SHOW_INTERVAL_NORMAL_MS) return;
+        } else {                                                      // No DCS-BIOS data in these modes: batch by loop count as before
+            updCountdown = (updCountdown == 0) ? 8 : updCountdown;
+            if (--updCountdown != 0) return;
         }
+
+        cli();
+        FastLED.show();
+        LedUpdateState::getInstance()->setUpdateFlag(false);          // Reset update flag
+        sei();
+        lastShowMs = millis();                                        // Start the listening window at the END of show()
     }
 
 


### PR DESCRIPTION
## Description

Investigating the FastLED interrupt logic, I found that a tming-based update countdown will work better and leave more room for DCS-Bios to send bytes before a FastLED update.  

Addresses, but does not close #164 

### Dependencies
--

### Type of change
- [ ] New software module (new software module for slave)
- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update outside of the automatically-generated Doxygen documentation.

### Checklist:
- [X] [I have complied with the software manual](https://docs.openhornet.com/software/d7/d78/md__software_manual.html) for this project, to include style requirements
- [X] I have incremented the version of the program in the header, using semantic versioning (Do not increment major version (x.0.0) until post-1.0 package release)
- [X] I have added myself as a co-author in the program header
- [X] I have performed a self-review of my own code
- [X] I have commented my code fully with Doxygen compatible comments, particularly in hard-to-understand areas, and reviewed previous comments in the code.
- [X] I have made corresponding changes to non-Doxygen generated documentation
- [ ] I have ran Doxygen locally, and it builds the docs successfully
- [X] My changes generate no errors on compile in Arduino IDE
- [X] My changes generate no new warnings on compile in Arduino IDE
- [X] Any dependent changes have been merged and published in downstream modules
- [ ] (For sketches only) This sketch complies with OH-INTERCONNECT v**<insert version number here>**
- [X] If this sketch requires additional libraries, [I have added it as a sub-module per the Arduino Libraries section of the Software Manual.](https://docs.openhornet.com/software/d7/d78/md__software_manual.html)

### How Has This Been Tested?

- [X] I have tested the sketch in-circuit in DCS with DCS-BIOS and outputs (displays, LEDs, etc.) function as expected. 
- [ ] I have tested the sketch in-circuit in DCS with DCS-BIOS and HID inputs (switches, pots, etc.) function as expected, with switches moving the correct direction.
- [X] I have tested the sketch in-circuit in DCS with DCS-BIOS and any logic in the sketch has been tested and functions as expected.
- [ ] This code has not yet been tested in-circuit.
- [ ] This code has not yet been tested in DCS-BIOS.

#### Description of Testing
Short in-DCS test with the "ready on ground" mission. INT LT test was also conducted to check delays. 


#### Test Configuration
* Firmware version:
* Hardware:
* Toolchain:
* SDK:
